### PR TITLE
protocol: Bound the 0x50 0x11 transaction reply to the buffer

### DIFF
--- a/src/datum_protocol.c
+++ b/src/datum_protocol.c
@@ -174,7 +174,7 @@ static atomic_bool datum_pool_abw_enabled = true;
 extern DATUM_QUEUE pow_queue;
 
 // may be used by this thread when crafting replies to server commands
-unsigned char temp_data[DATUM_PROTOCOL_MAX_CMD_DATA_SIZE + 16384];
+unsigned char temp_data[DATUM_PROTOCOL_TEMP_DATA_SIZE];
 
 unsigned char datum_protocol_setup_new_job_idx(void *sx) {
 	// Called by the stratum job updater.  Must be thread safe.
@@ -1634,9 +1634,17 @@ int datum_protocol_job_validation_stxlist(unsigned char *data) {
 	return 1;
 }
 
-int datum_protocol_job_validation_stxlist_byid(unsigned char *data) {
+// The 0x50 0x11 reply is built in temp_data and sent as one command, so it
+// must stay under what datum_protocol_bulk_cmd accepts with room for the 0xFE
+// terminator and up to 111 bytes of padding appended after the loop.
+bool datum_protocol_stxlist_reply_fits(size_t offset, size_t txn_size) {
+	return offset + 3 + txn_size <= DATUM_STXLIST_REPLY_MAX;
+}
+
+int datum_protocol_job_validation_stxlist_byid(int len, unsigned char *data) {
 	// the server is requesting missing transactions
 	// send them
+	if (len < 3) return 0;
 	unsigned char job_index = data[0];
 	uint16_t req_count = upk_u16le(data, 1);
 	
@@ -1654,6 +1662,23 @@ int datum_protocol_job_validation_stxlist_byid(unsigned char *data) {
 		msg[i] = 0x91; i++;
 		msg[i] = 0xFF; i++;
 		msg[i] = 0xF3; i++;
+		
+		// pad with some randomness
+		j = 1 + (rand() % 100);
+		memset(&msg[i], rand(), j);
+		i+=j;
+		
+		datum_protocol_mining_cmd(msg, i);
+		return 1;
+	}
+	
+	if (3 + 2 * (int)req_count > len) {
+		// the index list is shorter than the count claims
+		// error response to 0x50 0x11
+		msg[i] = 0x50; i++;
+		msg[i] = 0x91; i++;
+		msg[i] = job_index; i++;
+		msg[i] = 0xF4; i++;
 		
 		// pad with some randomness
 		j = 1 + (rand() % 100);
@@ -1736,6 +1761,28 @@ int datum_protocol_job_validation_stxlist_byid(unsigned char *data) {
 		if (req_id >= block_template->txn_count) {
 			// error....
 			pthread_rwlock_unlock(&datum_jobs_rwlock);
+			// error response to 0x50 0x11
+			i = 0; // reset index
+			msg[i] = 0x50; i++;
+			msg[i] = 0x91; i++;
+			msg[i] = job_index; i++;
+			msg[i] = 0xF4; i++;
+			
+			// pad with some randomness
+			j = 1 + (rand() % 100);
+			memset(&msg[i], rand(), j);
+			i+=j;
+			
+			datum_protocol_mining_cmd(msg, i);
+			return 1;
+		}
+		
+		// The count gate above does not stop a request that names the same
+		// index repeatedly, so bound the reply as it grows rather than trust
+		// the list to sum to at most one block.
+		if (!datum_protocol_stxlist_reply_fits((size_t)i, block_template->txns[req_id].size)) {
+			pthread_rwlock_unlock(&datum_jobs_rwlock);
+			DLOG_WARN("DATUM server requested %u transactions for job %d, more than one reply can carry; refusing", (unsigned)req_count, (int)job_index);
 			// error response to 0x50 0x11
 			i = 0; // reset index
 			msg[i] = 0x50; i++;
@@ -1968,7 +2015,7 @@ int datum_protocol_job_validation_cmd(int len, unsigned char *data) {
 		case 0x11: {
 			// send the requested txns
 			// 16-bit indexes
-			return datum_protocol_job_validation_stxlist_byid(p);
+			return datum_protocol_job_validation_stxlist_byid(len - 1, p);
 			break;
 		}
 		

--- a/src/datum_protocol_internal.h
+++ b/src/datum_protocol_internal.h
@@ -55,6 +55,14 @@ extern atomic_uint_fast64_t datum_session_generation;
 extern unsigned char datum_protocol_next_job_idx;
 extern T_DATUM_PROTOCOL_JOB datum_jobs[MAX_DATUM_PROTOCOL_JOBS];
 
+// Scratch buffer for replies built on the protocol thread, and the most a
+// 0x50 0x11 reply may hold before its terminator and padding.
+#define DATUM_PROTOCOL_TEMP_DATA_SIZE (DATUM_PROTOCOL_MAX_CMD_DATA_SIZE + 16384)
+#define DATUM_STXLIST_REPLY_MAX (DATUM_PROTOCOL_MAX_CMD_DATA_SIZE - 113)
+extern unsigned char temp_data[DATUM_PROTOCOL_TEMP_DATA_SIZE];
+bool datum_protocol_stxlist_reply_fits(size_t offset, size_t txn_size);
+int datum_protocol_job_validation_stxlist_byid(int len, unsigned char *data);
+
 uint32_t datum_header_xor_feedback(uint32_t i);
 int datum_protocol_flush_socket(int sockfd);
 void datum_protocol_bulk_reset(void);

--- a/src/datum_protocol_tests.c
+++ b/src/datum_protocol_tests.c
@@ -828,6 +828,95 @@ static void datum_pow_recycled_protocol_job_test(void) {
 	free(jobs);
 }
 
+static void datum_protocol_stxlist_byid_tests(void) {
+	// A 0x50 0x11 request names transaction indices with nothing against
+	// repeats, and the reply is built in the fixed temp_data buffer. The
+	// handler has to refuse a list the reply cannot hold instead of writing
+	// past the end of the buffer.
+	T_DATUM_STRATUM_JOB * const job = calloc(1, sizeof(*job));
+	T_DATUM_TEMPLATE_DATA * const block_template = calloc(1, sizeof(*block_template));
+	const uint32_t txn_size = 100000;
+	const uint32_t txn_count = 64;
+	T_DATUM_TEMPLATE_TXN * const txns = calloc(txn_count, sizeof(*txns));
+	unsigned char * const txn_data = malloc(txn_size);
+	unsigned char * const tail = temp_data + DATUM_PROTOCOL_TEMP_DATA_SIZE - 64;
+	unsigned char request[3 + 2 * 64];
+	unsigned char canary[64];
+	const int saved_out = server_out_buf;
+	const uint32_t saved_header_key = sending_header_key;
+	unsigned char saved_nonce[sizeof(session_nonce_sender)];
+	unsigned char job_index;
+	size_t k;
+	
+	memcpy(saved_nonce, session_nonce_sender, sizeof(saved_nonce));
+	datum_test(job && block_template && txns && txn_data);
+	if (!job || !block_template || !txns || !txn_data) goto cleanup;
+	
+	memset(txn_data, 0x5a, txn_size);
+	for (k = 0; k < txn_count; ++k) {
+		txns[k].size = txn_size;
+		txns[k].txn_data_binary = txn_data;
+	}
+	block_template->txn_count = txn_count;
+	block_template->txns = txns;
+	job->block_template = block_template;
+	snprintf(job->job_id, sizeof(job->job_id), "stxlist");
+	memset(datum_jobs, 0, sizeof(datum_jobs));
+	datum_protocol_next_job_idx = 0;
+	job_index = datum_protocol_setup_new_job_idx(job);
+	datum_jobs[job_index].server_sjob = job;
+	memcpy(datum_jobs[job_index].server_job_id, job->job_id,
+		sizeof(datum_jobs[job_index].server_job_id));
+	server_out_buf = 0;
+	memset(canary, 0xc7, sizeof(canary));
+	memcpy(tail, canary, sizeof(canary));
+	
+	// Two distinct transactions fit and are answered.
+	request[0] = job_index;
+	pk_u16le(request, 1, 2);
+	pk_u16le(request, 3, 0);
+	pk_u16le(request, 5, 1);
+	datum_test(datum_protocol_job_validation_stxlist_byid(7, request) == 1);
+	datum_test(temp_data[0] == 0x50 && temp_data[1] == 0x91);
+	datum_test(temp_data[2] == job_index && temp_data[3] == 0x01);
+	datum_test(upk_u16le(temp_data, 4) == 2);
+	datum_test(!memcmp(tail, canary, sizeof(canary)));
+	server_out_buf = 0;
+	
+	// The largest transaction 64 times over would need 6.4 MB. The count
+	// alone passes the txn_count gate; the reply must be refused.
+	pk_u16le(request, 1, 64);
+	for (k = 0; k < 64; ++k) pk_u16le(request, 3 + 2 * k, 0);
+	datum_test(datum_protocol_job_validation_stxlist_byid(3 + 2 * 64, request) == 1);
+	datum_test(temp_data[2] == job_index && temp_data[3] == 0xF4);
+	datum_test(!memcmp(tail, canary, sizeof(canary)));
+	server_out_buf = 0;
+	
+	// A list cut short of its count is refused before it is read.
+	pk_u16le(request, 1, 4);
+	temp_data[3] = 0;
+	datum_test(datum_protocol_job_validation_stxlist_byid(3 + 2 * 3, request) == 1);
+	datum_test(temp_data[2] == job_index && temp_data[3] == 0xF4);
+	datum_test(datum_protocol_job_validation_stxlist_byid(2, request) == 0);
+	
+	// The bound leaves room for the terminator and the padding.
+	datum_test(datum_protocol_stxlist_reply_fits(0, txn_size));
+	datum_test(datum_protocol_stxlist_reply_fits(DATUM_STXLIST_REPLY_MAX - 3 - txn_size, txn_size));
+	datum_test(!datum_protocol_stxlist_reply_fits(DATUM_STXLIST_REPLY_MAX - 2 - txn_size, txn_size));
+	
+cleanup:
+	datum_protocol_bulk_reset();
+	memset(datum_jobs, 0, sizeof(datum_jobs));
+	datum_protocol_next_job_idx = 0;
+	server_out_buf = saved_out;
+	sending_header_key = saved_header_key;
+	memcpy(session_nonce_sender, saved_nonce, sizeof(saved_nonce));
+	free(txn_data);
+	free(txns);
+	free(block_template);
+	free(job);
+}
+
 void datum_protocol_tests(void) {
 	datum_protocol_config_v3_tests();
 	datum_protocol_migration_tests();
@@ -836,4 +925,5 @@ void datum_protocol_tests(void) {
 	datum_protocol_abw_cache_tests();
 	datum_pow_response_large_difficulty_test();
 	datum_pow_recycled_protocol_job_test();
+	datum_protocol_stxlist_byid_tests();
 }


### PR DESCRIPTION
## What
Bounds the 0x50 0x11 missing-transaction reply to what `datum_protocol_bulk_cmd` accepts, and refuses an index list shorter than its count before reading it. Both cases answer with the existing 0xF4 error. Adds a test that requests one 100 KB transaction 64 times.

## Why
`datum_protocol_job_validation_stxlist_byid` copies each requested transaction into `temp_data` with no check on the running total. The only gate is count at most `txn_count`, and nothing stops the list from naming the same index every time, so 64 copies of a 100 KB transaction's index produce a 6.4 MB reply into a 4.2 MB buffer, which in .bss sits in front of the job lock and the job table. The list was also read past the message length, since the handler never received it. Inherited from the OCEAN import; the function is the same there and at innerhat.

## How I tested
The new test registers a job with 64 pointers to one 100 KB transaction and asks for index 0 sixty-four times. Without the bound glibc's fortify check aborts the run on the memcpy; with it the reply is refused and a canary at the end of `temp_data` is intact. Rebased onto b9ea7dc and run through the CI matrix locally (gcc and clang with `-Wall -Werror`, API off, the Umbrel define, ASan+UBSan): builds clean, `--test` passes. Not run against a live pool, which has no reason to send this.

## Risk and rollback
Only a request that would overflow, or whose list is shorter than its count, changes behavior, and those now get 0xF4 instead of memory corruption. A legitimate reply larger than the buffer could never be sent anyway. Revert the commit.

## Still unsure about
Whether you would rather deduplicate the index list as well. The bound alone makes it safe, so I kept it to that.
