### PR TITLE
submitblock: Treat a "duplicate" reply as the block being accepted

### DIFF
--- a/src/datum_stratum.c
+++ b/src/datum_stratum.c
@@ -2459,7 +2459,7 @@ int assembleBlockAndSubmit(uint8_t *block_header, uint8_t *coinbase_txn, size_t 
 	r = bitcoind_json_rpc_call(tcurl, &datum_config, submitblock_req);
 	curl_easy_cleanup(tcurl);
 	// The dedicated submitblock thread triggered above is still independently
-	// submitting this same block.
+	// submitting this same block, so one of the two is answered "duplicate".
 	ret = datum_submitblock_log_reply(r, block_hash_hex) ? 1 : 0;
 	if (r) json_decref(r);
 	

--- a/src/datum_stratum.c
+++ b/src/datum_stratum.c
@@ -2336,7 +2336,6 @@ int assembleBlockAndSubmit(uint8_t *block_header, uint8_t *coinbase_txn, size_t 
 	CURL *tcurl;
 	int ret = 0;
 	bool free_submitblock_req = false;
-	char *s = NULL;
 	unsigned char v2hdr[DATUM_BLAKE2B_BLOCK_HEADER_SIZE];
 	unsigned char merkle[32];
 	unsigned char en[12];
@@ -2459,32 +2458,10 @@ int assembleBlockAndSubmit(uint8_t *block_header, uint8_t *coinbase_txn, size_t 
 	// make the call!
 	r = bitcoind_json_rpc_call(tcurl, &datum_config, submitblock_req);
 	curl_easy_cleanup(tcurl);
-	if (!r) {
-		// Didn't get a usable response at all: either the request never reached the node, or it
-		// returned something we couldn't parse as a valid JSON-RPC reply, or a genuine top-level
-		// JSON-RPC error occurred. In every case we genuinely don't know if the block was
-		// accepted -- don't claim success. The dedicated submitblock thread triggered above is
-		// still independently submitting this same block.
-		DLOG_ERROR("Did not get a valid response submitting block %s! It may or may not have been accepted -- check your node!", block_hash_hex);
-		ret = 0;
-	} else {
-		json_t * const res_val = json_object_get(r, "result");
-		if (json_is_null(res_val)) {
-			// a null result means success here
-			DLOG_INFO("Block %s submitted to upstream node successfully!",block_hash_hex);
-			ret = 1;
-		} else {
-			s = json_dumps(res_val, JSON_ENCODE_ANY);
-			if (!s) {
-				DLOG_WARN("Upstream node rejected our block! (unknown)");
-			} else {
-				DLOG_WARN("Upstream node rejected our block! (%s)",s);
-				free(s);
-			}
-			ret = 0;
-		}
-		json_decref(r);
-	}
+	// The dedicated submitblock thread triggered above is still independently
+	// submitting this same block.
+	ret = datum_submitblock_log_reply(r, block_hash_hex) ? 1 : 0;
+	if (r) json_decref(r);
 	
 	// cleanup
 	if (free_submitblock_req) {

--- a/src/datum_submitblock.c
+++ b/src/datum_submitblock.c
@@ -69,14 +69,21 @@ datum_submitblock_status datum_submitblock_reply_status(const json_t *reply) {
 	if (!reply) return DATUM_SUBMITBLOCK_UNKNOWN;
 	const json_t * const result = json_object_get(reply, "result");
 	if (json_is_null(result)) return DATUM_SUBMITBLOCK_ACCEPTED;
+	if (json_is_string(result) && !strcmp(json_string_value(result), "duplicate")) return DATUM_SUBMITBLOCK_DUPLICATE;
 	return DATUM_SUBMITBLOCK_REJECTED;
 }
 
-// Log what the node said about our block. Returns true when the node took it.
+// Log what the node said about our block. Returns true when the block is in
+// the node's chain, which includes "duplicate": the block is handed in twice,
+// once inline from the share that found it and once from the submit thread,
+// and the second copy is not a rejection.
 bool datum_submitblock_log_reply(const json_t *reply, const char *block_hash_hex) {
 	switch (datum_submitblock_reply_status(reply)) {
 		case DATUM_SUBMITBLOCK_ACCEPTED:
 			DLOG_INFO("Block %s submitted to upstream node successfully!", block_hash_hex);
+			return true;
+		case DATUM_SUBMITBLOCK_DUPLICATE:
+			DLOG_INFO("Block %s was already accepted by the upstream node (duplicate submission)", block_hash_hex);
 			return true;
 		case DATUM_SUBMITBLOCK_UNKNOWN:
 			// Didn't get a usable response at all: either the request never reached the node, or it

--- a/src/datum_submitblock.c
+++ b/src/datum_submitblock.c
@@ -44,6 +44,7 @@
 #include "datum_utils.h"
 #include "datum_conf.h"
 #include "datum_jsonrpc.h"
+#include "datum_submitblock.h"
 
 pthread_mutex_t submitblock_mutex = PTHREAD_MUTEX_INITIALIZER;
 pthread_cond_t submitblock_cond = PTHREAD_COND_INITIALIZER;
@@ -64,37 +65,46 @@ void preciousblock(CURL *curl, char *blockhash) {
 	return;
 }
 
+datum_submitblock_status datum_submitblock_reply_status(const json_t *reply) {
+	if (!reply) return DATUM_SUBMITBLOCK_UNKNOWN;
+	const json_t * const result = json_object_get(reply, "result");
+	if (json_is_null(result)) return DATUM_SUBMITBLOCK_ACCEPTED;
+	return DATUM_SUBMITBLOCK_REJECTED;
+}
+
+// Log what the node said about our block. Returns true when the node took it.
+bool datum_submitblock_log_reply(const json_t *reply, const char *block_hash_hex) {
+	switch (datum_submitblock_reply_status(reply)) {
+		case DATUM_SUBMITBLOCK_ACCEPTED:
+			DLOG_INFO("Block %s submitted to upstream node successfully!", block_hash_hex);
+			return true;
+		case DATUM_SUBMITBLOCK_UNKNOWN:
+			// Didn't get a usable response at all: either the request never reached the node, or it
+			// returned something we couldn't parse as a valid JSON-RPC reply, or a genuine top-level
+			// JSON-RPC error occurred. In every case, we genuinely don't know whether the block was
+			// accepted -- don't claim success.
+			DLOG_ERROR("Did not get a valid response submitting block %s! It may or may not have been accepted -- check your node!", block_hash_hex);
+			return false;
+		case DATUM_SUBMITBLOCK_REJECTED:
+		default: {
+			char * const s = json_dumps(json_object_get(reply, "result"), JSON_ENCODE_ANY);
+			DLOG_WARN("Upstream node rejected our block! (%s)", s ? s : "unknown");
+			free(s);
+			return false;
+		}
+	}
+}
+
 void datum_submitblock_doit(CURL *tcurl, char *url, const char *submitblock_req, const char *block_hash_hex) {
 	json_t *r;
-	char *s = NULL;
 	// TODO: Move these types of things to the conf file
 	if (!url) {
 		r = bitcoind_json_rpc_call(tcurl, &datum_config, submitblock_req);
 	} else {
 		r = json_rpc_call(tcurl, url, NULL, submitblock_req);
 	}
-	if (!r) {
-		// Didn't get a usable response at all: either the request never reached the node, or it
-		// returned something we couldn't parse as a valid JSON-RPC reply, or a genuine top-level
-		// JSON-RPC error occurred. In every case, we genuinely don't know whether the block was
-		// accepted -- don't claim success.
-		DLOG_ERROR("Did not get a valid response submitting block %s! It may or may not have been accepted -- check your node!", block_hash_hex);
-	} else {
-		json_t * const res_val = json_object_get(r, "result");
-		if (json_is_null(res_val)) {
-			// a null result means success here
-			DLOG_INFO("Block %s submitted to upstream node successfully!",block_hash_hex);
-		} else {
-			s = json_dumps(res_val, JSON_ENCODE_ANY);
-			if (!s) {
-				DLOG_WARN("Upstream node rejected our block! (unknown)");
-			} else {
-				DLOG_WARN("Upstream node rejected our block! (%s)",s);
-				free(s);
-			}
-		}
-		json_decref(r);
-	}
+	datum_submitblock_log_reply(r, block_hash_hex);
+	if (r) json_decref(r);
 	
 	// precious block!
 	preciousblock(tcurl, submitblock_hash);

--- a/src/datum_submitblock.h
+++ b/src/datum_submitblock.h
@@ -37,6 +37,19 @@
 #define _DATUM_SUBMITBLOCK_H_
 
 #include <stdbool.h>
+#include <jansson.h>
+
+// What a submitblock reply means. The RPC helper returns NULL when there
+// was no usable reply at all, and the parsed reply otherwise.
+typedef enum {
+	DATUM_SUBMITBLOCK_UNKNOWN = 0,	// no usable reply: the node may or may not have the block
+	DATUM_SUBMITBLOCK_ACCEPTED,		// null result: the node took the block
+	DATUM_SUBMITBLOCK_REJECTED,		// anything else
+} datum_submitblock_status;
+
+datum_submitblock_status datum_submitblock_reply_status(const json_t *reply);
+bool datum_submitblock_log_reply(const json_t *reply, const char *block_hash_hex);
+void datum_submitblock_reply_tests(void);
 
 void datum_submitblock_init(void);
 void datum_submitblock_trigger(const char *ptr, const char *hash);

--- a/src/datum_submitblock.h
+++ b/src/datum_submitblock.h
@@ -44,7 +44,8 @@
 typedef enum {
 	DATUM_SUBMITBLOCK_UNKNOWN = 0,	// no usable reply: the node may or may not have the block
 	DATUM_SUBMITBLOCK_ACCEPTED,		// null result: the node took the block
-	DATUM_SUBMITBLOCK_REJECTED,		// anything else
+	DATUM_SUBMITBLOCK_DUPLICATE,	// "duplicate": the node already had it, and it is valid
+	DATUM_SUBMITBLOCK_REJECTED,		// anything else, including "duplicate-invalid"
 } datum_submitblock_status;
 
 datum_submitblock_status datum_submitblock_reply_status(const json_t *reply);

--- a/src/datum_submitblock_tests.c
+++ b/src/datum_submitblock_tests.c
@@ -34,6 +34,7 @@
  */
 
 #include <errno.h>
+#include <jansson.h>
 #include <pthread.h>
 #include <string.h>
 #include <time.h>
@@ -109,4 +110,32 @@ void datum_submitblock_tests(void) {
 	datum_test(state.requests[1] == second_request);
 	datum_test(!strcmp(state.hashes[0], first_hash));
 	datum_test(!strcmp(state.hashes[1], second_hash));
+	datum_submitblock_reply_tests();
+}
+
+static datum_submitblock_status status_of(const char * const json_text) {
+	json_t * const reply = json_loads(json_text, 0, NULL);
+	datum_test(reply != NULL);
+	const datum_submitblock_status st = datum_submitblock_reply_status(reply);
+	json_decref(reply);
+	return st;
+}
+
+void datum_submitblock_reply_tests(void) {
+	// No usable reply at all: the node may or may not have the block
+	datum_test(datum_submitblock_reply_status(NULL) == DATUM_SUBMITBLOCK_UNKNOWN);
+	
+	// The null result the node sends on acceptance
+	datum_test(status_of("{\"result\":null,\"error\":null,\"id\":1}") == DATUM_SUBMITBLOCK_ACCEPTED);
+	
+	// Already have it and it is valid: the block is in the chain
+	
+	datum_test(status_of("{\"result\":\"inconclusive\",\"error\":null,\"id\":1}") == DATUM_SUBMITBLOCK_REJECTED);
+	datum_test(status_of("{\"result\":\"bad-txnmrklroot\",\"error\":null,\"id\":1}") == DATUM_SUBMITBLOCK_REJECTED);
+	datum_test(status_of("{\"result\":\"prev-blk-not-found\",\"error\":null,\"id\":1}") == DATUM_SUBMITBLOCK_REJECTED);
+	
+	// A non-string or missing result is not something to call success
+	datum_test(status_of("{\"result\":true,\"error\":null,\"id\":1}") == DATUM_SUBMITBLOCK_REJECTED);
+	datum_test(status_of("{\"result\":{\"x\":1},\"error\":null,\"id\":1}") == DATUM_SUBMITBLOCK_REJECTED);
+	datum_test(status_of("{\"error\":null,\"id\":1}") == DATUM_SUBMITBLOCK_REJECTED);
 }

--- a/src/datum_submitblock_tests.c
+++ b/src/datum_submitblock_tests.c
@@ -129,7 +129,11 @@ void datum_submitblock_reply_tests(void) {
 	datum_test(status_of("{\"result\":null,\"error\":null,\"id\":1}") == DATUM_SUBMITBLOCK_ACCEPTED);
 	
 	// Already have it and it is valid: the block is in the chain
+	datum_test(status_of("{\"result\":\"duplicate\",\"error\":null,\"id\":1}") == DATUM_SUBMITBLOCK_DUPLICATE);
 	
+	// Every other string is a rejection, including the other duplicate-* forms
+	datum_test(status_of("{\"result\":\"duplicate-invalid\",\"error\":null,\"id\":1}") == DATUM_SUBMITBLOCK_REJECTED);
+	datum_test(status_of("{\"result\":\"duplicate-inconclusive\",\"error\":null,\"id\":1}") == DATUM_SUBMITBLOCK_REJECTED);
 	datum_test(status_of("{\"result\":\"inconclusive\",\"error\":null,\"id\":1}") == DATUM_SUBMITBLOCK_REJECTED);
 	datum_test(status_of("{\"result\":\"bad-txnmrklroot\",\"error\":null,\"id\":1}") == DATUM_SUBMITBLOCK_REJECTED);
 	datum_test(status_of("{\"result\":\"prev-blk-not-found\",\"error\":null,\"id\":1}") == DATUM_SUBMITBLOCK_REJECTED);


### PR DESCRIPTION
## What
A `submitblock` reply of `duplicate` is logged as "already accepted" at INFO instead of "Upstream node rejected our block!" at WARN, at both places the gateway submits a block, and the inline submit's return value counts it as success. The classification lives in one function, `datum_submitblock_reply_status()`, with tests.

## Why
The gateway hands a found block to the node twice, inline from the share that found it and again from the submit thread. The node answers the second copy with `duplicate`, which BIP22 defines as "already have it, and it is valid", and both call sites logged that as a rejection right after the real acceptance line. On 2026-08-30 a gateway that found mainnet block 961672 logged `submitted to upstream node successfully!` and the rejection warning five milliseconds later. `duplicate-invalid`, `inconclusive` and the `bad-*` reasons are still rejections.

## How I tested
Eleven reply cases in `datum_submitblock_tests()`: no reply, null result, `duplicate`, `duplicate-invalid`, `duplicate-inconclusive`, `inconclusive`, `bad-*` reasons, and non-string results. Rebased onto b9ea7dc and run through the CI matrix locally (gcc and clang with `-Wall -Werror`, API off, the Umbrel define, ASan+UBSan): builds clean, `--test` passes. The motivating line is from a real block; I have not found another since to see the new wording live.

## Risk and rollback
This is redone on top of 39e0de7, which made the RPC helper return the null-result reply instead of NULL. The earlier version of this change, innerhat #14, read NULL as success and would now hide a failed request, so this one supersedes it. The "may or may not have been accepted" error for no reply is kept. Revert the commit.
