### PR TITLE
jsonrpc: Log the node's error response instead of discarding it

### DIFF
--- a/src/datum_jsonrpc.c
+++ b/src/datum_jsonrpc.c
@@ -142,6 +142,7 @@ err_out:
 json_t *json_rpc_call_full(CURL *curl, const char *url, const char *userpass, const char *rpc_req, const char *extra_header, long * const http_resp_code_out) {
 	json_t *val, *err_val, *res_val;
 	CURLcode rc;
+	long http_resp_code = 0;
 	struct data_buffer all_data = { };
 	struct upload_buffer upload_data;
 	json_error_t err = { };
@@ -151,7 +152,9 @@ json_t *json_rpc_call_full(CURL *curl, const char *url, const char *userpass, co
 	
 	curl_easy_setopt(curl, CURLOPT_URL, url);
 	curl_easy_setopt(curl, CURLOPT_ENCODING, "");
-	curl_easy_setopt(curl, CURLOPT_FAILONERROR, 1L);
+	// No CURLOPT_FAILONERROR: bitcoind answers an RPC error with HTTP 500 and
+	// the reason in the body, which FAILONERROR would discard unread.
+	curl_easy_setopt(curl, CURLOPT_FAILONERROR, 0L);
 	curl_easy_setopt(curl, CURLOPT_TCP_NODELAY, 1L);
 	curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, all_data_cb);
 	curl_easy_setopt(curl, CURLOPT_WRITEDATA, &all_data);
@@ -184,8 +187,9 @@ json_t *json_rpc_call_full(CURL *curl, const char *url, const char *userpass, co
 	curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
 	
 	rc = curl_easy_perform(curl);
+	curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_resp_code);
+	if (http_resp_code_out) *http_resp_code_out = http_resp_code;
 	if (rc) {
-		if (http_resp_code_out) curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, http_resp_code_out);
 		DLOG_DEBUG("json_rpc_call: HTTP request failed: %s", curl_err_str);
 		DLOG_DEBUG("json_rpc_call: Request was: %s",rpc_req);
 		goto err_out;
@@ -193,7 +197,13 @@ json_t *json_rpc_call_full(CURL *curl, const char *url, const char *userpass, co
 	
 	val = JSON_LOADS(all_data.buf, &err);
 	if (!val) {
-		DLOG_DEBUG("JSON decode failed(%d): %s", err.line, err.text);
+		if (http_resp_code == 401) {
+			DLOG_DEBUG("json_rpc_call: HTTP 401 from %s (credentials refused)", url);
+		} else if (http_resp_code >= 400) {
+			DLOG_ERROR("json_rpc_call: HTTP %ld from %s", http_resp_code, url);
+		} else {
+			DLOG_DEBUG("JSON decode failed(%d): %s", err.line, err.text);
+		}
 		goto err_out;
 	}
 	
@@ -225,6 +235,18 @@ json_t *json_rpc_call_full(CURL *curl, const char *url, const char *userpass, co
 			
 			goto err_out;
 		}
+	}
+	
+	if (http_resp_code >= 400) {
+		// An error status with a well-formed result is not something to trust.
+		// 401 is the cookie having rotated under us; the caller re-reads it.
+		if (http_resp_code == 401) {
+			DLOG_DEBUG("json_rpc_call: HTTP 401 from %s (credentials refused)", url);
+		} else {
+			DLOG_ERROR("json_rpc_call: HTTP %ld from %s", http_resp_code, url);
+		}
+		json_decref(val);
+		goto err_out;
 	}
 	
 	databuf_free(&all_data);


### PR DESCRIPTION
## What
The RPC helper stops setting `CURLOPT_FAILONERROR`, reads the body bitcoind sends with an HTTP 500, and logs the node's error object at ERROR on one line. A non-JSON body on an error status logs the status, with 401 named as an authentication failure. An error status still fails the call.

## Why
bitcoind answers an RPC error with HTTP 500 and the reason in the body. With FAILONERROR curl reported the status and dropped the body unread, so the only trace was a DEBUG line, and at the default level an operator sees "Could not fetch new template" once a second with nothing about why. The case that matters on this chain: a node that requires the blake2b rule tells a gateway configured for sha256d exactly that, "Support for 'blake2b' rule requires explicit client support", and the message never reached the log.

## How I tested
Against a fake node answering 500 with a -8 error body the log shows the node's message; against one answering 401 it shows the status and the cookie retry in `bitcoind_json_rpc_call` still fires, since the HTTP status is now captured on every path. Rebased onto b9ea7dc and run through the CI matrix locally (gcc and clang with `-Wall -Werror`, API off, the Umbrel define, ASan+UBSan): builds clean, `--test` passes.

## Risk and rollback
Callers see the same failures as before; only the log changes. The decref that 39e0de7 added on the error path moves to `err_out`, so every exit frees the parsed reply once. Revert the commit.
