### PR TITLE
protocol: XOR the packed header through memcpy

### DIFF
--- a/src/datum_protocol.c
+++ b/src/datum_protocol.c
@@ -202,8 +202,15 @@ unsigned char datum_protocol_setup_new_job_idx(void *sx) {
 	return a;
 }
 
+_Static_assert(sizeof(T_DATUM_PROTOCOL_HEADER) == sizeof(uint32_t), "T_DATUM_PROTOCOL_HEADER must be four bytes");
+
 static inline void datum_xor_header_key(void *h, uint32_t key) {
-	*((uint32_t *)h) ^= key;
+	// The header is packed and may sit at any address, so go through memcpy
+	// rather than storing through a uint32_t pointer.
+	uint32_t v;
+	memcpy(&v, h, sizeof(v));
+	v ^= key;
+	memcpy(h, &v, sizeof(v));
 }
 
 uint32_t datum_header_xor_feedback(const uint32_t i) {

--- a/src/datum_protocol_tests.c
+++ b/src/datum_protocol_tests.c
@@ -130,7 +130,13 @@ static int datum_protocol_test_decrypt_frame(const unsigned char *wire,
 	size_t clear_size) {
 	if (*offset + sizeof(*header) > wire_size) return -1;
 	memcpy(header, wire + *offset, sizeof(*header));
-	*((uint32_t *)header) ^= *header_key;
+	{
+		// packed header: XOR through a copy, same as datum_xor_header_key
+		uint32_t v;
+		memcpy(&v, header, sizeof(v));
+		v ^= *header_key;
+		memcpy(header, &v, sizeof(v));
+	}
 	*header_key = datum_header_xor_feedback(*header_key);
 	*offset += sizeof(*header);
 	if (!header->is_encrypted_channel || header->cmd_len < crypto_box_MACBYTES ||


### PR DESCRIPTION
## What
`datum_xor_header_key` and the test helper that mirrors it XOR the packed protocol header through a `uint32_t` copy instead of a `uint32_t *` store. A static assert pins the header at four bytes.

## Why
`T_DATUM_PROTOCOL_HEADER` is packed, so a header on the stack or inside a wire buffer can sit at any address, and storing through a `uint32_t *` there is undefined behavior. x86 tolerates it. A build with `-fsanitize=undefined` and no address sanitizer aborts `--test` at datum_protocol_tests.c:133 on the first decrypted frame. CI does not see it because it combines ASan, whose stack realignment happens to align that header.

## How I tested
On master b9ea7dc a clang build with `-fsanitize=undefined -fno-sanitize-recover=all` fails `--test` at that line; with this change it passes. gcc and clang `-Wall -Werror`, API off, and ASan+UBSan also build clean and pass `--test`.

## Risk and rollback
No wire or behavior change; the same four bytes are XORed with the same key. Revert the commit.
