### PR TITLE
logger: Set the queue and the log file up before the writer thread starts

### DIFF
--- a/src/datum_gateway.c
+++ b/src/datum_gateway.c
@@ -196,7 +196,11 @@ int main(const int argc, const char * const * const argv) {
 	datum_gateway_config_filename = arguments.config_file;
 	
 	// Initialize logger thread
-	datum_logger_init();
+	if (datum_logger_init()) {
+		DLOG_FATAL("Error initializing the logger!");
+		usleep(100000);
+		exit(1);
+	}
 	
 	if (datum_protocol_init()) {
 		DLOG_FATAL("Error initializing the DATUM protocol!");

--- a/src/datum_logger.c
+++ b/src/datum_logger.c
@@ -58,6 +58,7 @@
 const char *level_text[] = { "  ALL", "DEBUG", " INFO", " WARN", "ERROR", "FATAL" };
 
 volatile bool datum_logger_initialized = false;
+static FILE *log_handle = NULL;
 volatile bool log_reopen_signal = false;
 
 // configurable options
@@ -260,37 +261,9 @@ void * datum_logger_thread(void *ptr) {
 	DLOG_MSG *msg;
 	char time_buffer[20];
 	char log_line[1200];
-	FILE *log_handle = NULL;
 	time_t next_log_rotate = get_midnight_timestamp();
 	time_t log_file_opened = time(NULL);
 	
-	msg_buffer[0] = calloc((DLOG_MSG_BUF_SIZE * 2) + (1024*8),1);
-	if (!msg_buffer[0]) {
-		DLOG(DLOG_LEVEL_FATAL, "Could not allocate memory for logger queue!");
-		panic_from_thread(__LINE__);
-	}
-	// split the allocation in half for the double buffering
-	msg_buffer[1] = &msg_buffer[0][DLOG_MSG_BUF_SIZE + (1024*4)];
-	
-	dlog_queue_max_entries = (DLOG_MSG_BUF_SIZE / sizeof(DLOG_MSG)) - 1;
-	if (dlog_queue_max_entries < 1024) dlog_queue_max_entries = 1024;
-	dlog_queue[0] = calloc(dlog_queue_max_entries * 2 * sizeof(DLOG_MSG),1);
-	if (!dlog_queue[0]) {
-		DLOG(DLOG_LEVEL_FATAL, "Could not allocate memory for logger queue list!");
-		panic_from_thread(__LINE__);
-	}
-	dlog_queue[1] = &dlog_queue[0][dlog_queue_max_entries];
-	
-	if ((log_to_file) && (log_file[0] != 0)) {
-		log_handle = fopen(log_file,"a");
-		if (!log_handle) {
-			DLOG(DLOG_LEVEL_FATAL, "Could not open log file (%s): %s!", log_file, strerror(errno));
-			panic_from_thread(__LINE__);
-		}
-	}
-	
-	// alert the masses.
-	datum_logger_initialized = true;
 	
 	DLOG(DLOG_LEVEL_DEBUG, "Logging thread started! (Approximately %d MB of RAM allocated for up to %d entries per cycle)", (DLOG_MSG_BUF_SIZE * 4)/1024/1024, dlog_queue_max_entries);
 	lflush = 0;
@@ -462,6 +435,35 @@ int datum_logger_init(void) {
 	}
 	
 	pthread_t pthread_datum_logger_thread;
+	
+	// Set the queue and the log file up here, before the writer thread
+	// exists, so a message logged right after init has somewhere to go.
+	msg_buffer[0] = calloc((DLOG_MSG_BUF_SIZE * 2) + (1024*8),1);
+	if (!msg_buffer[0]) {
+		DLOG(DLOG_LEVEL_FATAL, "Could not allocate memory for logger queue!");
+		return -1;
+	}
+	// split the allocation in half for the double buffering
+	msg_buffer[1] = &msg_buffer[0][DLOG_MSG_BUF_SIZE + (1024*4)];
+	
+	dlog_queue_max_entries = (DLOG_MSG_BUF_SIZE / sizeof(DLOG_MSG)) - 1;
+	if (dlog_queue_max_entries < 1024) dlog_queue_max_entries = 1024;
+	dlog_queue[0] = calloc(dlog_queue_max_entries * 2 * sizeof(DLOG_MSG),1);
+	if (!dlog_queue[0]) {
+		DLOG(DLOG_LEVEL_FATAL, "Could not allocate memory for logger queue list!");
+		return -1;
+	}
+	dlog_queue[1] = &dlog_queue[0][dlog_queue_max_entries];
+	
+	if ((log_to_file) && (log_file[0] != 0)) {
+		log_handle = fopen(log_file,"a");
+		if (!log_handle) {
+			DLOG(DLOG_LEVEL_FATAL, "Could not open log file (%s): %s!", log_file, strerror(errno));
+			return -1;
+		}
+	}
+	
+	datum_logger_initialized = true;
 	
 	pthread_create(&pthread_datum_logger_thread, NULL, datum_logger_thread, NULL);
 	


### PR DESCRIPTION
## What
`datum_logger_init` does the logger's setup itself, the queue allocation and opening the log file, before it starts the writer thread. The thread keeps only its loop.

## Why
It started the thread and returned at once. Anything logged in the next millisecond, which includes `datum_protocol_init` and `datum_api_init`, went to the console if console logging was on and nowhere if it was off. With `log_to_console: false` and a log file, the `DATUM pool host is blank. NON-POOLED MINING!` warning never reached the file.

The first version of this PR waited for the thread instead. Doing the setup in init removes the window rather than waiting it out, and it makes a setup failure an init failure: it now returns -1 like the other init functions and main exits on it, where the thread's `panic_from_thread()` would only have spun.

## How I tested
Same config both ways, file on, console off, a gateway pointed at an unreachable node, five seconds. On master the file starts several lines in and the startup key and warning lines are missing; with this change the file starts with them. An unwritable log path now logs two FATAL lines and exits. Built with `-Wall -Werror`, `--test` passes.

## Risk and rollback
None to the running loop; the log handle moved from a thread local to file scope, which the rotate path already treated as shared. Revert the commit.
