### PR TITLE
stratum: Name the client that found a block

### DIFF
--- a/src/datum_protocol.c
+++ b/src/datum_protocol.c
@@ -637,6 +637,8 @@ typedef struct {
 	T_DATUM_ABW_TEMPLATE *block_template;
 	bool subsidy_only;
 	bool pool_handled;
+	char finder[DATUM_ABW_FINDER_LEN];
+	uint64_t height;
 } T_DATUM_ABW_PENDING;
 
 static pthread_mutex_t datum_abw_mutex = PTHREAD_MUTEX_INITIALIZER;
@@ -783,11 +785,13 @@ static bool datum_protocol_abw_template_matches_source(
 }
 
 // Caller holds datum_abw_mutex and transfers ownership of coinbase.
+// finder describes the client for the log and is copied.
 static void datum_protocol_abw_populate_pending(
 	T_DATUM_ABW_PENDING *pending, T_DATUM_ABW_TEMPLATE *block_template,
 	const T_DATUM_PROTOCOL_POW *pow, unsigned char *coinbase,
 	size_t coinbase_size, const unsigned char raw_pow_hash[32],
-	const unsigned char block_header[DATUM_BLAKE2B_BLOCK_HEADER_SIZE]) {
+	const unsigned char block_header[DATUM_BLAKE2B_BLOCK_HEADER_SIZE],
+	const char *finder) {
 	pending->assignment_id = pow->abw_assignment_id;
 	pending->nonce = (uint32_t)pow->nonce;
 	pending->target_pot = pow->target_byte;
@@ -798,6 +802,8 @@ static void datum_protocol_abw_populate_pending(
 		DATUM_BLAKE2B_BLOCK_HEADER_SIZE);
 	pending->coinbase = coinbase;
 	pending->coinbase_size = coinbase_size;
+	snprintf(pending->finder, sizeof(pending->finder), "%s", finder ? finder : "");
+	pending->height = pow->sjob->height;
 	pending->block_template = block_template;
 	pending->subsidy_only = pow->subsidy_only;
 	if (block_template) block_template->refs++;
@@ -805,7 +811,7 @@ static void datum_protocol_abw_populate_pending(
 
 bool datum_protocol_abw_cache_candidate(const T_DATUM_PROTOCOL_POW *pow,
 	const unsigned char *full_cb_tx, size_t full_cb_tx_size,
-	const unsigned char *raw_pow_hash) {
+	const unsigned char *raw_pow_hash, const char *finder) {
 	static const unsigned char no_xor_key[16] = {0};
 	if (!pow || !pow->sjob || !pow->sjob->block_template ||
 	    !full_cb_tx || !raw_pow_hash || !pow->abw_assignment_id ||
@@ -868,13 +874,13 @@ bool datum_protocol_abw_cache_candidate(const T_DATUM_PROTOCOL_POW *pow,
 	}
 	if (pending && block_template) {
 		datum_protocol_abw_populate_pending(pending, block_template, pow,
-			coinbase, full_cb_tx_size, raw_pow_hash, block_header);
+			coinbase, full_cb_tx_size, raw_pow_hash, block_header, finder);
 		pthread_mutex_unlock(&datum_abw_mutex);
 		return true;
 	}
 	if (pending && pow->subsidy_only) {
 		datum_protocol_abw_populate_pending(pending, NULL, pow,
-			coinbase, full_cb_tx_size, raw_pow_hash, block_header);
+			coinbase, full_cb_tx_size, raw_pow_hash, block_header, finder);
 		pthread_mutex_unlock(&datum_abw_mutex);
 		return true;
 	}
@@ -967,7 +973,7 @@ bool datum_protocol_abw_cache_candidate(const T_DATUM_PROTOCOL_POW *pow,
 	}
 	free(transactions_hex);
 	datum_protocol_abw_populate_pending(pending, block_template, pow,
-		coinbase, full_cb_tx_size, raw_pow_hash, block_header);
+		coinbase, full_cb_tx_size, raw_pow_hash, block_header, finder);
 	pthread_mutex_unlock(&datum_abw_mutex);
 	return true;
 }
@@ -1083,7 +1089,7 @@ int datum_protocol_abw_assignment_notice(int len, unsigned char *data) {
 static char *datum_protocol_abw_take_revealed_candidate_locked(
 	uint8_t assignment_id, const unsigned char xor_key[16],
 	const unsigned char expected_pow_hash[32], char block_hash[65],
-	bool *pool_handled) {
+	bool *pool_handled, char *finder, size_t finder_size, uint64_t *height) {
 	for (size_t i = 0; i < DATUM_ABW_PENDING_CACHE; ++i) {
 		T_DATUM_ABW_PENDING *pending = &datum_abw_pending[i];
 		if (pending->assignment_id != assignment_id) continue;
@@ -1133,6 +1139,10 @@ static char *datum_protocol_abw_take_revealed_candidate_locked(
 			pending->raw_pow_hash, pending->xor_clear_bits, xor_key,
 			actual_pow_hash, block_hash)) {
 			if (pool_handled) *pool_handled = pending->pool_handled;
+			if (finder && finder_size) {
+				snprintf(finder, finder_size, "%s", pending->finder);
+			}
+			if (height) *height = pending->height;
 			datum_protocol_abw_pending_clear(pending);
 			return candidate;
 		}
@@ -1185,11 +1195,18 @@ int datum_protocol_abw_reveal(int len, unsigned char *data) {
 	while (true) {
 		char block_hash[65] = {0};
 		bool pool_handled = false;
+		char finder[DATUM_ABW_FINDER_LEN] = "";
+		uint64_t height = 0;
 		pthread_mutex_lock(&datum_abw_mutex);
 		char *block_request = datum_protocol_abw_take_revealed_candidate_locked(
-			assignment_id, data + 2, NULL, block_hash, &pool_handled);
+			assignment_id, data + 2, NULL, block_hash, &pool_handled, finder,
+			sizeof(finder), &height);
 		pthread_mutex_unlock(&datum_abw_mutex);
 		if (!block_request) break;
+		if (finder[0]) {
+			DLOG_WARN("Block %s at height %llu found by %s", block_hash,
+				(unsigned long long)height, finder);
+		}
 		if (datum_config.mining_abw_verify_all_shares_on_disclosure &&
 		    !pool_handled) {
 			ignored_block = true;
@@ -2668,8 +2685,12 @@ int datum_protocol_pow_submit(
 		DLOG_ERROR("Could not submit POW for a disclosed anti-withholding assignment");
 		return -1;
 	}
+	char finder[320] = "";
+	if (pow.abw_assignment_id && c) {
+		datum_stratum_describe_block_finder(finder, sizeof(finder), c, username, subsidy_only);
+	}
 	if (pow.abw_assignment_id && !datum_protocol_abw_cache_candidate(
-		&pow, full_cb_tx, full_cb_tx_size, raw_pow_hash)) {
+		&pow, full_cb_tx, full_cb_tx_size, raw_pow_hash, finder)) {
 		DLOG_ERROR("BLAKE2b anti-withholding candidate cache is full");
 		return -1;
 	}

--- a/src/datum_protocol_internal.h
+++ b/src/datum_protocol_internal.h
@@ -73,11 +73,14 @@ T_DATUM_REPLAY_PENDING *datum_protocol_replay_add(
 void datum_protocol_replay_mark_responded_legacy(
 	uint32_t nonce, uint8_t target_pot, uint8_t job_id);
 
+// Room for the description of the client that found a pending ABW candidate
+#define DATUM_ABW_FINDER_LEN 320
+
 void datum_protocol_abw_reset(void);
 bool datum_protocol_abw_assignment_revealed(uint8_t assignment_id);
 bool datum_protocol_abw_cache_candidate(const T_DATUM_PROTOCOL_POW *pow,
 	const unsigned char *full_cb_tx, size_t full_cb_tx_size,
-	const unsigned char *raw_pow_hash);
+	const unsigned char *raw_pow_hash, const char *finder);
 int datum_protocol_abw_candidate_receipt(int len, unsigned char *data);
 int datum_protocol_abw_candidate_release(int len, unsigned char *data);
 int datum_protocol_abw_activation(int len, unsigned char *data);

--- a/src/datum_protocol_tests.c
+++ b/src/datum_protocol_tests.c
@@ -583,7 +583,7 @@ static void datum_protocol_abw_cache_tests(void) {
 	pow.target_byte = 10;
 	pow.nonce = 7;
 	pow.ntime = 1000;
-	datum_test(datum_protocol_abw_cache_candidate(&pow, coinbase, sizeof(coinbase), raw_hash));
+	datum_test(datum_protocol_abw_cache_candidate(&pow, coinbase, sizeof(coinbase), raw_hash, "tester from 192.0.2.1 (client 0/1, session 00400001, agent test)"));
 	
 	datum_config.mining_abw_verify_all_shares_on_disclosure = true;
 	unsigned char receipt[35] = {DATUM_ABW_DRAFT_REVISION, 3};
@@ -595,7 +595,7 @@ static void datum_protocol_abw_cache_tests(void) {
 	unsigned char second_hash[32];
 	memset(second_hash, 0xfe, sizeof(second_hash));
 	pow.nonce++;
-	datum_test(datum_protocol_abw_cache_candidate(&pow, coinbase, sizeof(coinbase), second_hash));
+	datum_test(datum_protocol_abw_cache_candidate(&pow, coinbase, sizeof(coinbase), second_hash, NULL));
 	datum_config.mining_abw_verify_all_shares_on_disclosure = false;
 	memcpy(pow.raw_pow_hash, second_hash, sizeof(pow.raw_pow_hash));
 	static const unsigned char replay_message[] = {0x27, 0xFE};
@@ -617,12 +617,12 @@ static void datum_protocol_abw_cache_tests(void) {
 	memset(subsidy_hash, 0xfc, sizeof(subsidy_hash));
 	pow.subsidy_only = true;
 	pow.nonce++;
-	datum_test(datum_protocol_abw_cache_candidate(&pow, coinbase, sizeof(coinbase), subsidy_hash));
+	datum_test(datum_protocol_abw_cache_candidate(&pow, coinbase, sizeof(coinbase), subsidy_hash, NULL));
 	pow.subsidy_only = false;
 	
 	datum_test(datum_protocol_abw_reveal(sizeof(reveal), reveal));
 	datum_test(datum_protocol_abw_assignment_revealed(4));
-	datum_test(!datum_protocol_abw_cache_candidate(&pow, coinbase, sizeof(coinbase), raw_hash));
+	datum_test(!datum_protocol_abw_cache_candidate(&pow, coinbase, sizeof(coinbase), raw_hash, NULL));
 	reveal[18] = 0;
 	datum_test(!datum_protocol_abw_reveal(sizeof(reveal), reveal));
 	reveal[18] = 0xFE;

--- a/src/datum_stratum.c
+++ b/src/datum_stratum.c
@@ -966,6 +966,17 @@ static void stratum_note_share(T_DATUM_MINER_DATA *m, bool accepted, uint64_t di
 	}
 }
 
+// Name the client behind a block for the log. Used by the local path
+// below and by the ABW reveal in datum_protocol.c. The username comes
+// straight from mining.submit, so it is filtered here; the user agent was
+// already filtered by strncpy_uachars at subscribe.
+void datum_stratum_describe_block_finder(char *out, size_t outsz, const T_DATUM_CLIENT_DATA *c, const char *username, bool empty_work) {
+	const T_DATUM_MINER_DATA * const m = c->app_client_data;
+	char who[192];
+	strncpy_printable(who, username ? username : "NULL", sizeof(who));
+	snprintf(out, outsz, "%s from %s (client %d/%d, session %08x, agent %s%s)", who, c->rem_host, c->datum_thread->thread_id, c->cid, m->sid, m->useragent[0] ? m->useragent : "unknown", empty_work ? ", on empty work" : "");
+}
+
 int client_mining_submit(T_DATUM_CLIENT_DATA *c, uint64_t id, json_t *params_obj) {
 	// {"params": ["username", "job", "extranonce2", "time", "nonce"], "id": 1, "method": "mining.submit"}
 	// 0 = username
@@ -1261,6 +1272,11 @@ int client_mining_submit(T_DATUM_CLIENT_DATA *c, uint64_t id, json_t *params_obj
 		DLOG_WARN("************************************************************************************************");
 		DLOG_WARN("******** BLOCK FOUND - %s ********", new_notify_blockhash);
 		DLOG_WARN("************************************************************************************************");
+		{
+			char finder[320];
+			datum_stratum_describe_block_finder(finder, sizeof(finder), c, username_s, empty_work);
+			DLOG_WARN("Block %s at height %llu found by %s", new_notify_blockhash, (unsigned long long)job->height, finder);
+		}
 		
 		if (job->is_datum_job) {
 			(void)datum_protocol_pow_submit(c, job, username_s, true,

--- a/src/datum_stratum.h
+++ b/src/datum_stratum.h
@@ -278,6 +278,7 @@ void stratum_job_merkle_root_calc(T_DATUM_STRATUM_JOB *s, unsigned char *coinbas
 int assembleBlockAndSubmit(uint8_t *block_header, uint8_t *coinbase_txn, size_t coinbase_txn_size, T_DATUM_STRATUM_JOB *job, T_DATUM_STRATUM_THREADPOOL_DATA *sdata, const char *block_hash_hex, bool empty_work, const unsigned char *extranonce);
 size_t datum_stratum_coinbase_for_block_hex(char *out, size_t out_size, const uint8_t *coinbase_txn, size_t coinbase_txn_size, bool add_witness);
 bool datum_stratum_block_needs_witness(const T_DATUM_STRATUM_JOB *job, bool subsidy_only);
+void datum_stratum_describe_block_finder(char *out, size_t outsz, const T_DATUM_CLIENT_DATA *c, const char *username, bool empty_work);
 size_t datum_stratum_build_block_request_parts(char *out, size_t out_size,
 	const uint8_t *block_header,
 	const uint8_t *coinbase_txn, size_t coinbase_txn_size, bool add_witness,

--- a/src/datum_utils.c
+++ b/src/datum_utils.c
@@ -580,6 +580,25 @@ bool strncpy_workerchars(char *out, const char *in, size_t maxlen) {
 	return true;
 }
 
+bool strncpy_printable(char *out, const char *in, size_t maxlen) {
+	// copy a string from in to out for the log, replacing anything outside
+	// printable ASCII with '?' so a client cannot put line breaks or terminal
+	// escapes into the log
+	// copy a max of maxlen-1 chars from in to out
+	size_t i = 0;
+
+	if (in == NULL || out == NULL || maxlen == 0) {
+		return false;
+	}
+
+	for (; in[i] != 0 && i + 1 < maxlen; i++) {
+		const unsigned char c = (unsigned char)in[i];
+		out[i] = (c >= 0x20 && c <= 0x7e) ? (char)c : '?';
+	}
+	out[i] = 0;
+	return true;
+}
+
 bool strncpy_uachars(char *out, const char *in, size_t maxlen) {
 	// copy a string from in to out, stripping out unwanted characters
 	// copy a max of maxlen chars from in to out

--- a/src/datum_utils.h
+++ b/src/datum_utils.h
@@ -80,6 +80,7 @@ void uchar_to_hex(char *s, const unsigned char b);
 int get_bitcoin_varint_len_bytes(uint64_t n);
 bool strncpy_uachars(char *out, const char *in, size_t maxlen);
 bool strncpy_workerchars(char *out, const char *in, size_t maxlen);
+bool strncpy_printable(char *out, const char *in, size_t maxlen);
 long double calc_network_difficulty(const char *bits_hex);
 unsigned char floorPoT(uint64_t x);
 uint64_t datum_siphash(const void *src, uint64_t sz, const unsigned char key[16]);

--- a/src/datum_utils_tests.c
+++ b/src/datum_utils_tests.c
@@ -141,9 +141,25 @@ static void datum_utils_tests_pdiff_to_bdiff(void) {
 	datum_test(datum_pdiff_to_bdiff(16) == 15.999755859375L);
 }
 
+static void datum_utils_tests_strncpy_printable(void) {
+	char out[8];
+	datum_test(!strncpy_printable(out, NULL, sizeof(out)));
+	datum_test(!strncpy_printable(NULL, "x", sizeof(out)));
+	datum_test(!strncpy_printable(out, "x", 0));
+	datum_test(strncpy_printable(out, "ab\n\x1b[1m", sizeof(out)));
+	datum_test(strcmp(out, "ab??[1m") == 0);
+	datum_test(strncpy_printable(out, "0123456789", sizeof(out)));
+	datum_test(strcmp(out, "0123456") == 0);
+	datum_test(strncpy_printable(out, "\xc3\xa9", sizeof(out)));
+	datum_test(strcmp(out, "??") == 0);
+	datum_test(strncpy_printable(out, "", sizeof(out)));
+	datum_test(out[0] == 0);
+}
+
 void datum_utils_tests(void) {
 	datum_utils_tests_hex();
 	datum_utils_tests_secure_strequals();
 	datum_utils_tests_scriptnum();
 	datum_utils_tests_pdiff_to_bdiff();
+	datum_utils_tests_strncpy_printable();
 }


### PR DESCRIPTION
## What
One more WARN line naming the client behind a found block: the height, the username the share was submitted under, the client address, its thread and slot, the session id, the user agent, and whether the share was on empty work. It fires on both paths a block can take: right after the BLOCK FOUND banner in `client_mining_submit`, and in `datum_protocol_abw_reveal` when the pool discloses the XOR key for an ABW candidate.

## Why
The banner prints only the hash. I had to decode the session id out of the header's extranonce and work through thread assignment order to tell my own ASIC apart from rented hashpower. The session id in the new line is what the gateway writes into the header's extranonce, so an on-chain block now matches a log line directly. Thread, slot and address are the fields the idle-kick messages already print.

Under ABW the share is not recognizable as a block when it arrives, so each pending candidate keeps a copy of the description (one pointer and the height per entry, freed with the candidate) and the reveal path logs it before queuing the block. One helper in `datum_stratum.c` builds the line for both paths.

The username comes straight from `mining.submit` and this is the first time it reaches the log, so `strncpy_printable` in `datum_utils` turns anything outside printable ASCII into `?` first. The user agent is already filtered by `strncpy_uachars` at subscribe.

## How I tested
CI matrix on b9ea7dc: gcc and clang with `-Wall -Werror`, `ENABLE_API=OFF`, `DATUM_API_FOR_UMBREL`, and ASan with leak detection all build clean and pass `--test`. UBSan alone stops at the pre-existing misaligned store in `datum_protocol_tests.c:133` that #5 fixes; with #5 on top it passes. `strncpy_printable` has a unit test. The existing ABW candidate/reveal test now passes a description through the cache so ASan checks the copy is freed. The log line itself only fires on a block; the first version of the local line is running on my solo gateway and its output is unchanged by this revision.

## Risk and rollback
Log output only, no behavior change. The pending-candidate cache grows by 16 bytes per entry, about 1 MB static at 65536 entries. The line does put the finder's username and address in the log at WARN, the same information the dashboard shows; an operator who pastes logs in public should know it is there. Revert the commit.
