### PR TITLE
protocol: Take the coinbaser lock before sending the request

### DIFF
--- a/src/datum_protocol.c
+++ b/src/datum_protocol.c
@@ -1327,26 +1327,37 @@ int datum_protocol_coinbaser_fetch(void *sptr) {
 		return 0;
 	}
 	
-	if (datum_protocol_mining_cmd_for_session(
-		msg, i, session_generation) != 0) return 0;
-	
-	// spin here for up to 5 seconds while awaiting a coinbaser response from the DATUM server
-	clock_gettime(CLOCK_REALTIME, &ts);
-	ts.tv_sec += 5; // Set timeout to 5 seconds
-	
+	// Hold the mutex from before the request goes out until the reply is consumed, so the
+	// receive thread cannot store and signal a reply before this thread is waiting for it.
+	// The send only appends to the outgoing buffer; it never blocks on the socket.
 	pthread_mutex_lock(&datum_protocol_coinbaser_fetch_mutex);
+	datum_coinbaser_v2_response = NULL;
 	
-	rc = pthread_cond_timedwait(&datum_protocol_coinbaser_fetch_cond, &datum_protocol_coinbaser_fetch_mutex, &ts);
-	if (rc == ETIMEDOUT) {
+	if (datum_protocol_mining_cmd_for_session(
+		msg, i, session_generation) != 0) {
 		pthread_mutex_unlock(&datum_protocol_coinbaser_fetch_mutex);
-		DLOG_DEBUG("Timeout waiting for coinbaser response from DATUM server");
 		return 0;
 	}
 	
-	if (rc != 0) {
-		DLOG_DEBUG("Error waiting for coinbaser response from DATUM server");
-		pthread_mutex_unlock(&datum_protocol_coinbaser_fetch_mutex);
-		return 0;
+	// wait here for up to 5 seconds for a coinbaser response from the DATUM server
+	clock_gettime(CLOCK_REALTIME, &ts);
+	ts.tv_sec += 5; // Set timeout to 5 seconds
+
+	// Loop on the reply for this job's value: a stale reply or a spurious wakeup is not the answer.
+	while ((!datum_coinbaser_v2_response) ||
+	       (datum_coinbaser_v2_response_value[datum_coinbaser_v2_response_buf_idx] != value)) {
+		rc = pthread_cond_timedwait(&datum_protocol_coinbaser_fetch_cond, &datum_protocol_coinbaser_fetch_mutex, &ts);
+		if (rc == ETIMEDOUT) {
+			pthread_mutex_unlock(&datum_protocol_coinbaser_fetch_mutex);
+			DLOG_DEBUG("Timeout waiting for coinbaser response from DATUM server");
+			return 0;
+		}
+
+		if (rc != 0) {
+			DLOG_DEBUG("Error waiting for coinbaser response from DATUM server");
+			pthread_mutex_unlock(&datum_protocol_coinbaser_fetch_mutex);
+			return 0;
+		}
 	}
 	i = 0;
 	


### PR DESCRIPTION
## What
`datum_protocol_coinbaser_fetch()` takes the coinbaser mutex before it sends the request, clears any stale reply under it, and waits in a loop until the reply for this job's value has arrived. The send return is unlocked and reported as before.

## Why
The requester sent the request first and only then took the mutex and called `pthread_cond_timedwait`. A reply that arrived in between was stored and signaled with nobody waiting, so the fetch sat out the full five seconds and returned 0. `datum_coinbaser.c` then generated the job with `available_coinbase_outputs_count` at 0, which in a DATUM job means `empty_only`: the coinbase pays the whole reward to the pool script with none of the miner outputs the coinbaser would have given it, and `need_coinbaser` is cleared so the job is never retried. The window is the round trip to the pool, which is why a nearby pool hits it more often. The old wait also took any wakeup as the answer, including a stale reply for the previous job or a spurious return from `pthread_cond_timedwait`.

Holding the mutex across the send is safe: `datum_protocol_mining_cmd_for_session` only appends to the outgoing buffer under the sender locks and never blocks on the socket, and the receive thread takes the coinbaser mutex without holding anything else, so there is no ordering the other way.

This is OCEAN-xyz/datum_gateway#229 by Fudmottin, adapted to the session-checked send path here. The response handler keeps its timed lock, which is harmless now that the requester holds the mutex only for the buffer append or while blocked in the condition wait.

## How I tested
Read, not reproduced: the race needs a reply to land inside a few microseconds after the send, and I have no harness that drives the encrypted pool channel. Rebased onto b9ea7dc and run through the CI matrix locally (gcc and clang with `-Wall -Werror`, API off, the Umbrel define, ASan+UBSan): builds clean, `--test` passes, identical to master. A UBSan-only build trips the pre-existing `datum_protocol_tests.c:133` store on master and here alike; #5 covers that. `git diff --check` clean.

## Risk and rollback
The only behavior change on the success path is that a reply is now consumed by the request that asked for it. Revert the commit.
