### PR TITLE
stratum: Serve every miner the largest coinbase class on BLAKE2b work

### DIFF
--- a/src/datum_coinbaser.c
+++ b/src/datum_coinbaser.c
@@ -206,9 +206,21 @@ void generate_coinbase_txns_for_stratum_job_subtypebysize(T_DATUM_STRATUM_JOB *s
 	// technically an output script could be > 0x4B, meaning an extra byte would be eaten here... but that's not currently the standard
 	// this needs to match the loop lower in this function, as the count will get thrown off if it does not.
 	
-	// TODO: Enforce max sigops! Note: This is not currently enforced in eloipool, either, so punting for now and will monitor network stats to determine priority.
+	// The sigop cost available to these outputs: the template's sigoplimit
+	// (from GBT, in sigop cost units, where one legacy CHECKSIG counts 4) minus
+	// the cost of the template's transactions and minus the cost of the pool's
+	// own output. available_coinbase_outputs[].sigops is set by the coinbaser
+	// parser: 4 for a script whose first byte is OP_DUP (0x76, P2PKH) and 0
+	// for every other script. The pool output is charged the same way. An
+	// output whose cost exceeds the remaining budget is skipped, the same as an
+	// output that exceeds the remaining size, in both this counting pass and
+	// the writing pass below.
+	int64_t sigops_budget = (int64_t)s->block_template->sigoplimit - (int64_t)s->block_template->txn_total_sigops;
+	if ((s->pool_addr_script_len > 0) && (s->pool_addr_script[0] == 0x76)) sigops_budget -= 4;
+	if (sigops_budget < 0) sigops_budget = 0;
+	int64_t sigops_left = sigops_budget;
 	for(k=0;k<s->available_coinbase_outputs_count;k++) {
-		if (((s->available_coinbase_outputs[k].output_script_len+9) <= i) && ((mval + s->available_coinbase_outputs[k].value_sats) <= s->coinbase_value))  {
+		if (((s->available_coinbase_outputs[k].output_script_len+9) <= i) && ((mval + s->available_coinbase_outputs[k].value_sats) <= s->coinbase_value) && (s->available_coinbase_outputs[k].sigops <= sigops_left))  {
 			if ((special_coinb1) && (!c1full) && ((s->available_coinbase_outputs[k].output_script_len+9) <= i2)) {
 				i2 -= (s->available_coinbase_outputs[k].output_script_len+9);
 				c1cnt++;
@@ -217,6 +229,7 @@ void generate_coinbase_txns_for_stratum_job_subtypebysize(T_DATUM_STRATUM_JOB *s
 			}
 			
 			i -= (s->available_coinbase_outputs[k].output_script_len+9);
+			sigops_left -= s->available_coinbase_outputs[k].sigops;
 			m++;
 			mval += s->available_coinbase_outputs[k].value_sats;
 			if (i < 30) break;
@@ -244,9 +257,11 @@ void generate_coinbase_txns_for_stratum_job_subtypebysize(T_DATUM_STRATUM_JOB *s
 	
 	// append "m" payouts. find them the same way we did before
 	mval = 0;
+	sigops_left = sigops_budget;
 	for(k=0;k<s->available_coinbase_outputs_count;k++) {
-		if (((s->available_coinbase_outputs[k].output_script_len+9) <= j) && ((mval + s->available_coinbase_outputs[k].value_sats) <= s->coinbase_value)) {
+		if (((s->available_coinbase_outputs[k].output_script_len+9) <= j) && ((mval + s->available_coinbase_outputs[k].value_sats) <= s->coinbase_value) && (s->available_coinbase_outputs[k].sigops <= sigops_left)) {
 			j -= (s->available_coinbase_outputs[k].output_script_len+9);
+			sigops_left -= s->available_coinbase_outputs[k].sigops;
 			m--;
 			
 			mval += s->available_coinbase_outputs[k].value_sats;

--- a/src/datum_coinbaser.c
+++ b/src/datum_coinbaser.c
@@ -322,7 +322,7 @@ void generate_coinbase_txns_for_stratum_job_subtypebysize(T_DATUM_STRATUM_JOB *s
 		cb2idx[coinbase_index] += sprintf(&s->coinbase[coinbase_index].coinb2[cb2idx[coinbase_index]], "0000000000000000036a0100"); // TODO: Is a naked OP_RETURN without any bytes after safe?  Above TODO is probably better than investigating.
 	}
 	
-	// witness commit output costs 46 bytes
+	// witness commitment output costs 47 bytes (8 value, 1 length, 38 script)
 	// append the default_witness_commitment
 	cb2idx[coinbase_index] += sprintf(&s->coinbase[coinbase_index].coinb2[cb2idx[coinbase_index]], "0000000000000000%2.2x%s", (unsigned int)strlen(s->block_template->default_witness_commitment)>>1, s->block_template->default_witness_commitment);
 	// lock time
@@ -341,8 +341,13 @@ int datum_stratum_coinbase_fit_to_template(int max_sz, int fixed_bytes, T_DATUM_
 		msz1 = j;
 	}
 	
-	if (((i<<2)+s->block_template->txn_total_weight+340+36) > s->block_template->weightlimit) {
-		j = ((s->block_template->weightlimit - (s->block_template->txn_total_weight+340+36))>>2) - fixed_bytes;
+	// Block weight: four units a byte for the header and the transaction count
+	// (at most five bytes), four a byte for the coinbase (no witness data of
+	// its own) plus the 36 bytes of witness the node adds to it (marker, flag,
+	// one 32-byte item), and the template's transactions at their weight. The
+	// original 340 covered the 80-byte SHA256d header.
+	if (((i<<2)+s->block_template->txn_total_weight+((DATUM_BLAKE2B_BLOCK_HEADER_SIZE+5)<<2)+36) > s->block_template->weightlimit) {
+		j = ((s->block_template->weightlimit - (s->block_template->txn_total_weight+((DATUM_BLAKE2B_BLOCK_HEADER_SIZE+5)<<2)+36))>>2) - fixed_bytes;
 		if (j < 0) return 0;
 		msz1 = j;
 	}
@@ -470,7 +475,7 @@ void generate_base_coinbase_txns_for_stratum_job(T_DATUM_STRATUM_JOB *s, bool ne
 		k = cb2idx[0];
 	}
 	
-	// witness commit output costs 46 bytes
+	// witness commitment output costs 47 bytes (8 value, 1 length, 38 script)
 	// append the default_witness_commitment
 	cb2idx[0] += sprintf(&s->coinbase[0].coinb2[cb2idx[0]], "0000000000000000%2.2x%s", (unsigned int)strlen(s->block_template->default_witness_commitment)>>1, s->block_template->default_witness_commitment);
 	// lock time
@@ -676,7 +681,7 @@ void generate_coinbase_txns_for_stratum_job(T_DATUM_STRATUM_JOB *s, bool empty_o
 		k = cb2idx[0];
 	}
 	
-	// witness commit output costs 46 bytes
+	// witness commitment output costs 47 bytes (8 value, 1 length, 38 script)
 	// append the default_witness_commitment
 	cb2idx[0] += sprintf(&s->coinbase[0].coinb2[cb2idx[0]], "0000000000000000%2.2x%s", (unsigned int)strlen(s->block_template->default_witness_commitment)>>1, s->block_template->default_witness_commitment);
 	// lock time
@@ -702,7 +707,7 @@ void generate_coinbase_txns_for_stratum_job(T_DATUM_STRATUM_JOB *s, bool empty_o
 		// ok, let's figure out how much space, if any, we have for miner payout outputs
 		// we first need to figure out how much space we are using for each type after required data, so let's do that
 		
-		// witness output = 46 bytes
+		// witness commitment output = 47 bytes (8 value, 1 length, 38 script)
 		// pool output = pool_addr_script_len + 9
 		// coinbase itself = cb_input_sz
 		// coinbase len = 1
@@ -710,17 +715,23 @@ void generate_coinbase_txns_for_stratum_job(T_DATUM_STRATUM_JOB *s, bool empty_o
 		// lock time = 4 bytes
 		// "sequence" = 4 bytes
 		// extranonce size = 15 bytes (w/len push needed for either coinbase or OP_RETURN formats)
-		// output count... could technically be up to three bytes for types 3 + 4, most likely 1 byte for 0,1,2.
-		//     --- lets give ourselves the wiggle room and say 3 bytes
+		// output count: one byte up to 252 outputs, three bytes past that (the
+		// largest class holds several hundred); counted at three so the coinbase
+		// never exceeds what datum_stratum_coinbase_fit_to_template allowed.
 		//
-		// total static bytes = 46+9+1+41+4+3+4+15 = 123 bytes
+		// total static bytes = 47+9+1+41+4+3+4+15 = 124 bytes
 		// not-static bytes = pool_addr_script_len + cb_input_sz + (space_for_en_in_coinbase?0:10)
 		//     --- it costs 10 extra bytes to do the OP_RETURN based extranonce
+		//
+		// This was 119, three bytes under the transaction with a one-byte output
+		// count and five under it with a three-byte count; a coinbase built to a
+		// template's room then exceeded the block's weight limit by up to 20
+		// weight units.
 		
 		if (!space_for_en_in_coinbase) {
-			cb_req_sz[1] = cb_req_sz[2] = cb_req_sz[3] = cb_req_sz[4] = cb_req_sz[5] = 119 + s->pool_addr_script_len + cb_input_sz + 10;
+			cb_req_sz[1] = cb_req_sz[2] = cb_req_sz[3] = cb_req_sz[4] = cb_req_sz[5] = 124 + s->pool_addr_script_len + cb_input_sz + 10;
 		} else {
-			cb_req_sz[1] = cb_req_sz[2] = cb_req_sz[3] = cb_req_sz[4] = cb_req_sz[5] = 119 + s->pool_addr_script_len + cb_input_sz;
+			cb_req_sz[1] = cb_req_sz[2] = cb_req_sz[3] = cb_req_sz[4] = cb_req_sz[5] = 124 + s->pool_addr_script_len + cb_input_sz;
 			cb_req_sz[2] += 10; // always OP_RETURN extranonce for type 2
 		}
 		

--- a/src/datum_coinbaser_tests.c
+++ b/src/datum_coinbaser_tests.c
@@ -40,6 +40,7 @@
 #include "datum_stratum.h"
 #include "datum_coinbaser.h"
 #include "datum_utils.h"
+#include "datum_pow.h"
 
 int datum_stratum_coinbase_fit_to_template(
 	int max_sz, int fixed_bytes, T_DATUM_STRATUM_JOB *s);
@@ -74,6 +75,19 @@ static void datum_blake2b_coinbase_limit_tests(void) {
 	
 	/* The 164-byte header shrinks the coinbase leftover by 84 bytes. */
 	datum_test(datum_stratum_coinbase_fit_to_template(1000, 0, &job) == 866);
+	
+	/* The weight limit: the header and a five-byte count at four units a byte,
+	 * the coinbase's 36 witness bytes, then 950 bytes of coinbase at four
+	 * each. With the 80-byte header's 340 the leftover was 1000 (unbound). */
+	tdata.sizelimit = 4000000;
+	tdata.weightlimit = ((DATUM_BLAKE2B_BLOCK_HEADER_SIZE + 5) * 4) + 36 + (4 * 950);
+	datum_test(datum_stratum_coinbase_fit_to_template(1000, 0, &job) == 950);
+	/* The transactions' weight counts the same way. */
+	tdata.txn_total_weight = 4000;
+	tdata.weightlimit += 4000;
+	datum_test(datum_stratum_coinbase_fit_to_template(1000, 0, &job) == 950);
+	/* Fixed bytes are subtracted from the leftover. */
+	datum_test(datum_stratum_coinbase_fit_to_template(1000, 100, &job) == 850);
 }
 
 /* P2PKH: OP_DUP OP_HASH160 <20 bytes> OP_EQUALVERIFY OP_CHECKSIG, 25 bytes. */

--- a/src/datum_coinbaser_tests.c
+++ b/src/datum_coinbaser_tests.c
@@ -33,6 +33,7 @@
  *
  */
 
+#include <stdlib.h>
 #include <string.h>
 
 #include "datum_conf.h"
@@ -75,7 +76,74 @@ static void datum_blake2b_coinbase_limit_tests(void) {
 	datum_test(datum_stratum_coinbase_fit_to_template(1000, 0, &job) == 866);
 }
 
+/* P2PKH: OP_DUP OP_HASH160 <20 bytes> OP_EQUALVERIFY OP_CHECKSIG, 25 bytes. */
+static const unsigned char datum_test_p2pkh_script[25] = {0x76, 0xa9, 0x14, [23] = 0x88, 0xac};
+/* P2WPKH: OP_0 <20 bytes>, 22 bytes. */
+static const unsigned char datum_test_p2wpkh_script[22] = {0x00, 0x14};
+
+/* Builds one coinbase class with the template's used sigop cost set to
+ * sigops_used and the pool script set to P2PKH or P2WPKH, and returns the hex
+ * output count that follows the 8-character sequence at the start of coinb2.
+ * The count covers the included outputs plus the pool output and the witness
+ * commitment. The job's candidate outputs are two P2PKH outputs (cost 4 each)
+ * and one P2WPKH output (cost 0). */
+static const char *datum_coinbase_output_count_hex(T_DATUM_STRATUM_JOB *job, uint32_t sigops_used, bool pool_p2pkh) {
+	int cb1idx[MAX_COINBASE_TYPES] = {0};
+	int cb2idx[MAX_COINBASE_TYPES] = {0};
+	
+	job->block_template->txn_total_sigops = sigops_used;
+	if (pool_p2pkh) {
+		memcpy(job->pool_addr_script, datum_test_p2pkh_script, sizeof(datum_test_p2pkh_script));
+		job->pool_addr_script_len = sizeof(datum_test_p2pkh_script);
+	} else {
+		memcpy(job->pool_addr_script, datum_test_p2wpkh_script, sizeof(datum_test_p2wpkh_script));
+		job->pool_addr_script_len = sizeof(datum_test_p2wpkh_script);
+	}
+	memset(job->coinbase[1].coinb2, 0, sizeof(job->coinbase[1].coinb2));
+	generate_coinbase_txns_for_stratum_job_subtypebysize(job, 1, 1000, true, cb1idx, cb2idx, false);
+	return job->coinbase[1].coinb2 + 8;
+}
+
+static void datum_blake2b_coinbase_sigops_tests(void) {
+	T_DATUM_TEMPLATE_DATA tdata;
+	T_DATUM_STRATUM_JOB *job = calloc(1, sizeof(*job));
+	int k;
+	
+	datum_test(job != NULL);
+	if (!job) return;
+	memset(&tdata, 0, sizeof(tdata));
+	tdata.sigoplimit = 80000;
+	job->block_template = &tdata;
+	job->coinbase_value = 5000000000ULL;
+	for (k = 0; k < 3; k++) {
+		job->available_coinbase_outputs[k].value_sats = 100000000;
+		if (k < 2) {
+			memcpy(job->available_coinbase_outputs[k].output_script, datum_test_p2pkh_script, sizeof(datum_test_p2pkh_script));
+			job->available_coinbase_outputs[k].output_script_len = sizeof(datum_test_p2pkh_script);
+			job->available_coinbase_outputs[k].sigops = 4;
+		} else {
+			memcpy(job->available_coinbase_outputs[k].output_script, datum_test_p2wpkh_script, sizeof(datum_test_p2wpkh_script));
+			job->available_coinbase_outputs[k].output_script_len = sizeof(datum_test_p2wpkh_script);
+			job->available_coinbase_outputs[k].sigops = 0;
+		}
+	}
+	job->available_coinbase_outputs_count = 3;
+	
+	/* Space for every output: all three, the pool output and the witness commitment. */
+	datum_test(!strncmp(datum_coinbase_output_count_hex(job, 0, false), "05", 2));
+	/* Budget for one P2PKH output: the first P2PKH is included, the second is
+	 * skipped, and the P2WPKH is included. */
+	datum_test(!strncmp(datum_coinbase_output_count_hex(job, 80000 - 4, false), "04", 2));
+	/* Budget of 0: only the P2WPKH output is included. */
+	datum_test(!strncmp(datum_coinbase_output_count_hex(job, 80000, false), "03", 2));
+	/* A P2PKH pool output takes the remaining 4 units of the budget, so neither
+	 * P2PKH candidate is included. */
+	datum_test(!strncmp(datum_coinbase_output_count_hex(job, 80000 - 4, true), "03", 2));
+	free(job);
+}
+
 void datum_coinbaser_tests(void) {
 	datum_prime_id_64bit_tests();
 	datum_blake2b_coinbase_limit_tests();
+	datum_blake2b_coinbase_sigops_tests();
 }

--- a/src/datum_stratum.c
+++ b/src/datum_stratum.c
@@ -1450,15 +1450,20 @@ int client_mining_authorize(T_DATUM_CLIENT_DATA *c, uint64_t id, json_t *params_
 	return 0;
 }
 
+// The coinbase a BLAKE2b job commits to, the same for every miner: the
+// subsidy-only one for new-block work, COINBASE_TYPE_TINY (pays only the pool)
+// while the job state is below JOB_STATE_FULL_PRIORITY_WAIT_COINBASER or
+// full_coinbase_ready is unset, and COINBASE_TYPE_YUGE after that. The classes
+// were sized to what SHA256d firmware could accept (see the COINBASE_TYPE_
+// defines); on BLAKE2b work the miner never receives the coinbase, so there is
+// no per-miner selection.
 unsigned int datum_stratum_coinbase_index(
-	const T_DATUM_STRATUM_THREADPOOL_DATA *sdata,
-	const T_DATUM_MINER_DATA *miner, bool new_block) {
+	const T_DATUM_STRATUM_THREADPOOL_DATA *sdata, bool new_block) {
 	if (new_block) return DATUM_COINBASE_ID_EMPTY;
-	if (!sdata || !miner || !sdata->cur_stratum_job ||
+	if (!sdata || !sdata->cur_stratum_job ||
 	    sdata->cur_stratum_job->job_state < JOB_STATE_FULL_PRIORITY_WAIT_COINBASER ||
-	    !sdata->full_coinbase_ready ||
-	    miner->coinbase_selection >= MAX_COINBASE_TYPES) return 0;
-	return miner->coinbase_selection;
+	    !sdata->full_coinbase_ready) return 0;
+	return COINBASE_TYPE_YUGE;
 }
 
 int send_mining_notify(T_DATUM_CLIENT_DATA *c, bool clean, bool quickdiff, bool new_block) {
@@ -1552,7 +1557,7 @@ int send_mining_notify(T_DATUM_CLIENT_DATA *c, bool clean, bool quickdiff, bool 
 	const int notify_out_buf_start = c->out_buf;
 	datum_socket_send_string_to_client(c, "{\"id\":null,\"method\":\"mining.notify\",\"params\":[");
 	
-	cbselect = datum_stratum_coinbase_index(sdata, m, new_block);
+	cbselect = datum_stratum_coinbase_index(sdata, new_block);
 	const bool subsidy_only = cbselect == DATUM_COINBASE_ID_EMPTY;
 	cb = subsidy_only ? &j->subsidy_only_coinbase : &j->coinbase[cbselect];
 	
@@ -1622,64 +1627,18 @@ int send_mining_set_difficulty(T_DATUM_CLIENT_DATA *c) {
 void datum_stratum_fingerprint_by_UA(T_DATUM_MINER_DATA *m) {
 	// TODO: Make this a little more efficient. perhaps move to a loadable definitions file of some kind.
 	
-	if (strstr(m->useragent, "Antminer A3") == m->useragent) {
-		m->coinbase_selection = 0;
-		return;
-	}
-
-	// S21 tested to handle 2.25KB coinbase work on all versions released
-	// UA starts with: Antminer S21/
-	// S21 Pro NOT confirmed to work this way (yet)... so keep the /
-	if (strstr(m->useragent, "Antminer S21/") == m->useragent) {
-		m->coinbase_selection = 5; // ANTMAIN2
-		return;
-	}
-	
-	// the ePIC control boards can handle almost any size coinbase
-	// UA starts with: PowerPlay-BM/
-	if (strstr(m->useragent, "PowerPlay-BM/") == m->useragent) {
-		m->coinbase_selection = 4; // YUGE
-		return;
-	}
-	
-	// "vinsh" reports as xminer
-	// Tested to handle up to 16KB
-	if (strstr(m->useragent, "xminer-1.") == m->useragent) {
-		m->coinbase_selection = 4; // YUGE
-		return;
-	}
-	
-	// whatsminer works fine with about a 6.5 KB coinbase
-	// UA starts with: whatsminer/v1
-	if (strstr(m->useragent, "whatsminer/v1") == m->useragent) {
-		m->coinbase_selection = 3; // RESPECTABLE
-		return;
-	}
-	
-	// Braiins firmware
-	// Appears to handle arbitrary coinbase sizes, however not extensively tested on all firmware versions
-	// feed the S21-like coinbase for now, which is at least moderately sized
-	// UA contains: bosminer-plus-tuner
-	if (strstr(m->useragent, "bosminer-plus-tuner") != NULL) { // match anywhere in string, not just beginning
-		m->coinbase_selection = 5; // ANTMAIN2
-		return;
-	}
-	
-	// Nicehash, sadly needs a smaller coinbase than even antminer s19s
-	// they also need a high minimum difficulty
+	// For SHA256d work this function also chose the coinbase class the miner's
+	// firmware was known to accept: COINBASE_TYPE_TINY for the Antminer A3, the
+	// 2250-byte class for the Antminer S21 ("Antminer S21/") and Braiins
+	// ("bosminer-plus-tuner", matched anywhere in the string), 16000 for ePIC
+	// ("PowerPlay-BM/") and xminer ("xminer-1."), 6500 for Whatsminer
+	// ("whatsminer/v1") and the Bitaxe ("bitaxe"), 500 for NiceHash, and the
+	// 755-byte Antminer S19 class for everything else. BLAKE2b work serves
+	// every miner COINBASE_TYPE_YUGE (datum_stratum_coinbase_index), so only
+	// the NiceHash minimum difficulty remains.
 	if (strstr(m->useragent, "NiceHash/") == m->useragent) {
 		m->current_diff=524288;
 		m->forced_high_min_diff=524288;
-		m->coinbase_selection = 1; // TINY
-		return;
-	}
-	
-	// The Bitaxe is tested to work with a large coinbase
-	// However, it does slow work changes slightly when they're YUGE, so we'll go with
-	// the whatsminer tested size as a compromise.  also should save some bandwidth, which
-	// is probably not a bad plan, given the low odds of a bitaxe finding a block.
-	if (strstr(m->useragent, "bitaxe") == m->useragent) {
-		m->coinbase_selection = 3; // RESPECTABLE
 		return;
 	}
 }
@@ -1704,9 +1663,9 @@ int client_mining_subscribe(T_DATUM_CLIENT_DATA *c, uint64_t id, json_t *params_
 	// set default diff
 	m->current_diff = datum_config.stratum_v1_vardiff_min;
 	
-	// default to the antminer workaround, which appears to be universally compatible
-	// except for NiceHash.
-	m->coinbase_selection = 2;
+	// The class every miner is served on BLAKE2b work once the full coinbase is
+	// ready (datum_stratum_coinbase_index); kept per miner only for the API.
+	m->coinbase_selection = COINBASE_TYPE_YUGE;
 	
 	m->useragent[0] = 0;
 	if (params_obj) {

--- a/src/datum_stratum.h
+++ b/src/datum_stratum.h
@@ -57,6 +57,22 @@
 #define COINBASE_TYPE_RESPECTABLE 3 // 6500 byte max (whatsminers)
 #define COINBASE_TYPE_YUGE 4 // 16KB max (ePIC, bitaxe)
 #define COINBASE_TYPE_ANTMAIN2 5 // 2.25KB max (S21, +?)
+// The classes were sized to what SHA256d firmware could accept, since those
+// miners receive coinb1/coinb2 and hash the coinbase. On BLAKE2b work the
+// miner receives 000000 || H2 || 00000000 as coinb1 (H2 is the "Merge-mining
+// hook" tagged hash, which commits to the coinbase) and an empty coinb2, and
+// the work root is blake2b(0x00 || coinb1 || extranonce), so the coinbase
+// itself never reaches the miner. A smaller class therefore only omits some of
+// the pool's dictated outputs from the block; their value is paid to the
+// pool's address as the remainder. BLAKE2b work serves every miner
+// COINBASE_TYPE_YUGE once the full coinbase is ready and COINBASE_TYPE_TINY
+// before that (datum_stratum_coinbase_index); classes 1, 2, 3 and 5 are still
+// built, but their indexes never appear in a job id. The 16000-byte limit of
+// COINBASE_TYPE_YUGE covers the whole coinbase transaction
+// (datum_stratum_coinbase_fit_to_template subtracts the fixed bytes), so it
+// fits in STRATUM_COINBASE2_MAX_LEN (32768 hex characters, 16384 bytes) and
+// holds a little under 512 P2WPKH outputs (31 bytes each), the most a
+// coinbaser dictates, but only about 365 taproot outputs (43 bytes each).
 
 // Submitblock json rpc command max size is max block size * 2 for ascii plus some breathing room
 #define MAX_SUBMITBLOCK_SIZE 8500000
@@ -273,7 +289,7 @@ bool datum_stratum_job_blake2b_commitment_from_txn(const T_DATUM_STRATUM_JOB *s,
 bool datum_stratum_job_blake2b_commitment(T_DATUM_STRATUM_JOB *s, const T_DATUM_STRATUM_COINBASE *cb, bool subsidy_only, unsigned char pot, unsigned char *commitment, unsigned char *coinb1);
 bool datum_stratum_share_is_unmasked_block(
 	const T_DATUM_STRATUM_JOB *job, const unsigned char *share_hash);
-unsigned int datum_stratum_coinbase_index(const T_DATUM_STRATUM_THREADPOOL_DATA *sdata, const T_DATUM_MINER_DATA *miner, bool new_block);
+unsigned int datum_stratum_coinbase_index(const T_DATUM_STRATUM_THREADPOOL_DATA *sdata, bool new_block);
 void stratum_job_merkle_root_calc(T_DATUM_STRATUM_JOB *s, unsigned char *coinbase_txn_hash, unsigned char *merkle_root_output);
 int assembleBlockAndSubmit(uint8_t *block_header, uint8_t *coinbase_txn, size_t coinbase_txn_size, T_DATUM_STRATUM_JOB *job, T_DATUM_STRATUM_THREADPOOL_DATA *sdata, const char *block_hash_hex, bool empty_work, const unsigned char *extranonce);
 size_t datum_stratum_coinbase_for_block_hex(char *out, size_t out_size, const uint8_t *coinbase_txn, size_t coinbase_txn_size, bool add_witness);

--- a/src/datum_stratum_tests.c
+++ b/src/datum_stratum_tests.c
@@ -202,19 +202,21 @@ static void datum_blake2b_h_not_zero_tests(void) {
 static void datum_blake2b_coinbase_selection_tests(void) {
 	T_DATUM_STRATUM_THREADPOOL_DATA *sdata = calloc(1, sizeof(*sdata));
 	T_DATUM_STRATUM_JOB job = {0};
-	T_DATUM_MINER_DATA miner = {.coinbase_selection = 3};
 	
 	datum_test(sdata != NULL);
 	if (!sdata) return;
-	datum_test(datum_stratum_coinbase_index(sdata, &miner, true) == DATUM_COINBASE_ID_EMPTY);
-	datum_test(datum_stratum_coinbase_index(sdata, &miner, false) == 0);
+	datum_test(datum_stratum_coinbase_index(sdata, true) == DATUM_COINBASE_ID_EMPTY);
+	datum_test(datum_stratum_coinbase_index(sdata, false) == 0);
 	sdata->cur_stratum_job = &job;
 	sdata->full_coinbase_ready = true;
-	datum_test(datum_stratum_coinbase_index(sdata, &miner, false) == 0);
+	datum_test(datum_stratum_coinbase_index(sdata, false) == 0);
 	job.job_state = JOB_STATE_FULL_PRIORITY_WAIT_COINBASER;
-	datum_test(datum_stratum_coinbase_index(sdata, &miner, false) == 3);
-	miner.coinbase_selection = MAX_COINBASE_TYPES;
-	datum_test(datum_stratum_coinbase_index(sdata, &miner, false) == 0);
+	// With the job state at or above JOB_STATE_FULL_PRIORITY_WAIT_COINBASER and
+	// full_coinbase_ready set, every miner is served the largest class: there
+	// is no per-miner selection on BLAKE2b work.
+	datum_test(datum_stratum_coinbase_index(sdata, false) == COINBASE_TYPE_YUGE);
+	sdata->full_coinbase_ready = false;
+	datum_test(datum_stratum_coinbase_index(sdata, false) == 0);
 	free(sdata);
 }
 


### PR DESCRIPTION
The size classes were sized to what SHA256d firmware could accept, since
those miners receive coinb1/coinb2 and hash the coinbase. On BLAKE2b work
the miner receives 000000 || H2 || 00000000 as coinb1 and an empty coinb2,
and the work root is blake2b(0x00 || coinb1 || extranonce), so the coinbase
never reaches the miner. A smaller class therefore only omits some of the
pool's dictated outputs from the block; their value is paid to the pool's
address as the remainder. With the default class 2 (755 bytes) that is
about 18 P2WPKH outputs with the default coinbase tags; a pool with more
payout outputs than that in its split had the rest omitted from every block
found by such a miner, and an Antminer A3 was served class 0, which pays
only the pool address.

datum_stratum_coinbase_index now returns COINBASE_TYPE_YUGE for every miner
once the full coinbase is ready (job state at or above
JOB_STATE_FULL_PRIORITY_WAIT_COINBASER and full_coinbase_ready set);
fingerprinting keeps only the NiceHash minimum difficulty. Classes 1, 2, 3
and 5 are still built, but their indexes never appear in a job id.

coinbaser: Enforce the block sigop limit on payout outputs

With every miner served the largest class, a split can carry hundreds of
outputs, so the block's sigop limit must be enforced here. The budget is
the template's sigoplimit minus the sigop cost of its transactions and of
the pool output. Cost is four per P2PKH output and zero for every other
script, as recorded in available_coinbase_outputs[].sigops by the coinbaser
parser. The check is applied in both passes of
generate_coinbase_txns_for_stratum_job_subtypebysize so the output count
written to the varint matches the outputs written.