### PR TITLE
protocol: Bound the job-validation subcommands to the received length

### DIFF
--- a/src/datum_protocol.c
+++ b/src/datum_protocol.c
@@ -1469,7 +1469,8 @@ err:
 	return 1;
 }
 
-int datum_protocol_job_validation_stxlist(unsigned char *data) {
+int datum_protocol_job_validation_stxlist(int len, unsigned char *data) {
+	if (len < 1) return 0;
 	// similar to compact blocks, we're going to send a list of short transaction IDs for the requested job
 	unsigned char job_index = data[0];
 	T_DATUM_PROTOCOL_JOB *dj;
@@ -1634,7 +1635,8 @@ int datum_protocol_job_validation_stxlist(unsigned char *data) {
 	return 1;
 }
 
-int datum_protocol_job_validation_stxlist_byid(unsigned char *data) {
+int datum_protocol_job_validation_stxlist_byid(int len, unsigned char *data) {
+	if (len < 3) return 0;
 	// the server is requesting missing transactions
 	// send them
 	unsigned char job_index = data[0];
@@ -1731,6 +1733,11 @@ int datum_protocol_job_validation_stxlist_byid(unsigned char *data) {
 	pk_u16le(msg, i, req_count); i += 2;
 	
 	for(j=0;j<req_count;j++) {
+		if (k + 2 > len) {
+			// The server asked for more ids than it sent.
+			pthread_rwlock_unlock(&datum_jobs_rwlock);
+			return 0;
+		}
 		req_id = upk_u16le(data, k); k += 2;
 		
 		if (req_id >= block_template->txn_count) {
@@ -1781,7 +1788,8 @@ int datum_protocol_job_validation_stxlist_byid(unsigned char *data) {
 	return 1;
 }
 
-int datum_protocol_job_validation_sblock(unsigned char *data) {
+int datum_protocol_job_validation_sblock(int len, unsigned char *data) {
+	if (len < 1) return 0;
 	// the server decided our template probably is too unique from what it knows about, or was
 	// otherwise not able to validate the block using faster negotiations.
 	// It would like us to just send the entire transaction blob for validation as-is.
@@ -1950,31 +1958,29 @@ static int datum_protocol_job_validation_parent_fetch(
 }
 
 int datum_protocol_job_validation_cmd(int len, unsigned char *data) {
-	unsigned char cmd = data[0];
-	unsigned char *p = data;
-	
 	if (len < 2) return 0;
 	
-	p++;
+	const unsigned char cmd = data[0];
+	unsigned char *p = data + 1;
 	
 	// sub sub cmd
 	switch (cmd) {
 		case 0x10: {
 			// send short txn list
-			return datum_protocol_job_validation_stxlist(p);
+			return datum_protocol_job_validation_stxlist(len - 1, p);
 			break;
 		}
 		
 		case 0x11: {
 			// send the requested txns
 			// 16-bit indexes
-			return datum_protocol_job_validation_stxlist_byid(p);
+			return datum_protocol_job_validation_stxlist_byid(len - 1, p);
 			break;
 		}
 		
 		case 0x12: {
 			// send the entire block, except the coinbase txn
-			return datum_protocol_job_validation_sblock(p);
+			return datum_protocol_job_validation_sblock(len - 1, p);
 			break;
 		}
 		


### PR DESCRIPTION
## What
Bounds the DATUM job-validation subcommands to the number of bytes the server actually sent. `datum_protocol_job_validation_cmd()` read the subcommand byte before its `len < 2` check and then passed only a pointer, no length, to the stxlist, stxlist-by-id and sblock handlers.

## Why
`datum_protocol_mining_cmd5()` dispatches with `cmd_len` taken from the server's header, and the receive loop delivers exactly that many bytes, which can be as few as one. The subcommand handlers then read without knowing how much arrived. `_stxlist_byid()` is the sharp case: it reads a three-byte header (`job_index`, then `req_count`) and then two bytes per requested id, `req_count` bounded only against the template's transaction count, never against the received length. A short or crafted request reads past the frame, and with a valid job present the surplus is copied into the reply and sent back to the server. `server_recv_buffer` is a large static array, so on x86 this reads stale bytes rather than faulting, but it is an out-of-bounds read of attacker-influenced length reachable from the pool. This is the request-side companion to the reply-side bound already in the tree.

## How I tested
Found by a libFuzzer harness over `datum_protocol_mining_cmd5` (offered separately). Minimal reproducer, a command-5 plaintext of `50 11 00` (job validation, txn-by-id, one payload byte), read three bytes under AddressSanitizer before the fix and is clean after. Builds with `gcc -Wall -Werror`; `datum_gateway --test` passes. Each guard is a `return 0` on a frame too short for what the code then reads, so it is a no-op on any well-formed request and changes behavior only on the frames that previously read out of bounds.

## Risk and rollback
Valid pool traffic takes the same path. Revert the commit.
