### PR TITLE
utils: Guard roundDownToPowerOfTwo_64 against zero

### DIFF
--- a/src/datum_utils.c
+++ b/src/datum_utils.c
@@ -85,6 +85,7 @@ void datum_utils_init(void) {
 #ifdef __GNUC__
 // faster, less portable
 uint64_t roundDownToPowerOfTwo_64(uint64_t x) {
+	if (x == 0) return 0;  // __builtin_clzll(0) is undefined
 	return 1ULL << (63 - __builtin_clzll(x));
 }
 


### PR DESCRIPTION
## What
Returns 0 from `roundDownToPowerOfTwo_64(0)` instead of evaluating `1ULL << (63 - __builtin_clzll(0))`.

## Why
`__builtin_clzll(0)` is undefined. `floorPoT()` right below already guards its zero case; this helper did not. A DATUM server minimum-difficulty of 0 reaches it through client configuration, and the vardiff calculation reaches it from miner-driven values.

## How I tested
Found by a libFuzzer harness over `datum_protocol_mining_cmd5` (offered separately). Before the fix, UndefinedBehaviorSanitizer reports "passing zero to clz()" on a client-configuration command with a zero minimum difficulty; after it, clean. Builds with `gcc -Wall -Werror`; `datum_gateway --test` passes.

## Risk and rollback
Behaviour is unchanged for every non-zero input. Revert the commit.
