### PR TITLE
protocol: Make T_DATUM_PROTOCOL_HEADER serialisation explicit

### DIFF
--- a/src/datum_protocol.c
+++ b/src/datum_protocol.c
@@ -202,9 +202,6 @@ unsigned char datum_protocol_setup_new_job_idx(void *sx) {
 	return a;
 }
 
-static inline void datum_xor_header_key(void *h, uint32_t key) {
-	*((uint32_t *)h) ^= key;
-}
 
 uint32_t datum_header_xor_feedback(const uint32_t i) {
 	uint32_t s = 0xb10cfeed;
@@ -223,6 +220,30 @@ uint32_t datum_header_xor_feedback(const uint32_t i) {
 	h *= 0xc2b2ae35;
 	h ^= h >> 16;
 	return h;
+}
+
+void datum_header_pk(uint8_t * const dst, const size_t offset, const T_DATUM_PROTOCOL_HEADER * const h, uint32_t * const xor_key) {
+	uint32_t raw = (h->cmd_len & 0x3fffffUL) |
+	               ((uint32_t)h->is_signed << 24) |
+	               ((uint32_t)h->is_encrypted_pubkey << 25) |
+	               ((uint32_t)h->is_encrypted_channel << 26) |
+	               ((uint32_t)(h->proto_cmd & 0x1f) << 27);
+	raw ^= *xor_key;
+	*xor_key = datum_header_xor_feedback(*xor_key);
+	
+	pk_u32le(dst, offset, raw);
+}
+
+void datum_header_upk(T_DATUM_PROTOCOL_HEADER * const h, const uint8_t * const src, const size_t offset, uint32_t * const xor_key) {
+	uint32_t raw = upk_u32le(src, offset);
+	raw ^= *xor_key;
+	*xor_key = datum_header_xor_feedback(*xor_key);
+	
+	h->cmd_len              = raw & 0x003fffffUL;
+	h->is_signed            = raw & 0x01000000UL;
+	h->is_encrypted_pubkey  = raw & 0x02000000UL;
+	h->is_encrypted_channel = raw & 0x04000000UL;
+	h->proto_cmd            = (raw >> 27) & 0x1f;
 }
 
 // Take the hexidecimal public key string and store it in a DATUM_ENC_KEYS
@@ -312,7 +333,7 @@ static int datum_protocol_encrypted_cmd(uint8_t proto_cmd, const void *data,
 	h.proto_cmd = proto_cmd;
 	h.cmd_len = len;
 	h.cmd_len += crypto_box_MACBYTES;
-	const size_t frame_size = sizeof(T_DATUM_PROTOCOL_HEADER) +
+	const size_t frame_size = T_DATUM_PROTOCOL_HEADER_WIRE_BYTES +
 		(size_t)len + crypto_box_MACBYTES;
 	if (frame_size >= DATUM_PROTOCOL_BUFFER_SIZE) return -1;
 	
@@ -331,16 +352,13 @@ static int datum_protocol_encrypted_cmd(uint8_t proto_cmd, const void *data,
 	}
 	
 	unsigned char *encrypted = server_send_buffer + server_out_buf +
-		sizeof(T_DATUM_PROTOCOL_HEADER);
+		T_DATUM_PROTOCOL_HEADER_WIRE_BYTES;
 	crypto_box_easy_afternm(encrypted, data, len, session_nonce_sender,
 		session_precomp.precomp_remote);
 	//DLOG_DEBUG("mining cmd 5--- len %d, send header key %8.8x, raw %8.8lx", h.cmd_len, sending_header_key, (unsigned long)upk_u32le(h, 0));
-	datum_xor_header_key(&h, sending_header_key);
-	sending_header_key = datum_header_xor_feedback(sending_header_key);
+	datum_header_pk(server_send_buffer, server_out_buf, &h, &sending_header_key);
 	datum_increment_session_nonce(session_nonce_sender);
-	memcpy(server_send_buffer + server_out_buf, &h,
-		sizeof(T_DATUM_PROTOCOL_HEADER));
-	server_out_buf += sizeof(T_DATUM_PROTOCOL_HEADER);
+	server_out_buf += T_DATUM_PROTOCOL_HEADER_WIRE_BYTES;
 	server_out_buf += len + crypto_box_MACBYTES;
 	pthread_mutex_unlock(&datum_protocol_send_buffer_lock);
 	pthread_mutex_unlock(&datum_protocol_sender_stage1_lock);
@@ -2379,16 +2397,14 @@ int datum_protocol_send_hello(int sockfd) {
 	i+=crypto_sign_BYTES;
 	
 	// seal it up
-	crypto_box_seal(&enc_hello_msg[sizeof(T_DATUM_PROTOCOL_HEADER)], hello_msg, i, pool_keys.pk_x25519);
+	crypto_box_seal(&enc_hello_msg[T_DATUM_PROTOCOL_HEADER_WIRE_BYTES], hello_msg, i, pool_keys.pk_x25519);
 	i+=crypto_box_SEALBYTES;
 	
 	h.cmd_len = i;
 	
-	memcpy(enc_hello_msg, &h, sizeof(T_DATUM_PROTOCOL_HEADER));
-	
 	// apply our initial xor key to the header, just to obfuscate it a tiny bit
 	// kinda pointless, but ok
-	datum_xor_header_key(&enc_hello_msg[0], sending_header_key);
+	datum_header_pk(enc_hello_msg, 0, &h, &sending_header_key);
 	
 	DLOG_DEBUG("Sending handshake init (%d bytes)", h.cmd_len);
 	
@@ -2411,7 +2427,7 @@ int datum_protocol_send_hello(int sockfd) {
 	// FIXME: why is this mixed-endian?
 	//DLOG_DEBUG("Session Nonce: %8.8X%8.8X%8.8X%8.8X%8.8X%8.8X", upk_u32le(session_nonce_receiver, 0), upk_u32le(session_nonce_receiver, 4), upk_u32le(session_nonce_receiver, 8), upk_u32le(session_nonce_receiver, 12), upk_u32le(session_nonce_receiver, 16), upk_u32le(session_nonce_receiver, 20));
 	
-	return datum_protocol_chars_to_server(enc_hello_msg, i+sizeof(T_DATUM_PROTOCOL_HEADER));
+	return datum_protocol_chars_to_server(enc_hello_msg, i+T_DATUM_PROTOCOL_HEADER_WIRE_BYTES);
 }
 
 int datum_protocol_decrypt_sealed(T_DATUM_PROTOCOL_HEADER *h, unsigned char *data) {
@@ -2938,6 +2954,7 @@ void *datum_protocol_client(void *args) {
 	int pool_port;
 	bool break_again = false;
 	T_DATUM_PROTOCOL_HEADER s_header;
+	unsigned char s_header_wire[T_DATUM_PROTOCOL_HEADER_WIRE_BYTES];
 	datum_connection_configured = false;
 	datum_protocol_abw_deactivate();
 	
@@ -3191,7 +3208,7 @@ void *datum_protocol_client(void *args) {
 				case 1:
 				case 2:
 				case 3: {
-					n = recv(sockfd, ((unsigned char *)&s_header) + (sizeof(T_DATUM_PROTOCOL_HEADER) - protocol_state), protocol_state, MSG_DONTWAIT);
+					n = recv(sockfd, s_header_wire + (T_DATUM_PROTOCOL_HEADER_WIRE_BYTES - protocol_state), protocol_state, MSG_DONTWAIT);
 					if (n <= 0) {
 						if ((n < 0) && ((errno == EAGAIN || errno == EWOULDBLOCK))) {
 							continue;
@@ -3200,13 +3217,13 @@ void *datum_protocol_client(void *args) {
 						break_again = true; break;
 					}
 					
-					if ((n+(sizeof(T_DATUM_PROTOCOL_HEADER) - protocol_state)) != sizeof(T_DATUM_PROTOCOL_HEADER)) {
+					if ((n+(T_DATUM_PROTOCOL_HEADER_WIRE_BYTES - protocol_state)) != T_DATUM_PROTOCOL_HEADER_WIRE_BYTES) {
 						if ((n+protocol_state) > 4) {
 							DLOG_DEBUG("recv() issue. too many header bytes. protocol_state=%d, n=%d, errno=%d (%s)", protocol_state, n, errno, strerror(errno));
 							break_again = true; break;
 						}
 						
-						protocol_state = sizeof(T_DATUM_PROTOCOL_HEADER) - n - (sizeof(T_DATUM_PROTOCOL_HEADER) - protocol_state); // should give us a state equal to the number of. consoluted to show the process. (compiler optimizes)
+						protocol_state = T_DATUM_PROTOCOL_HEADER_WIRE_BYTES - n - (T_DATUM_PROTOCOL_HEADER_WIRE_BYTES - protocol_state); // should give us a state equal to the number of. consoluted to show the process. (compiler optimizes)
 						continue;
 					}
 					
@@ -3214,7 +3231,7 @@ void *datum_protocol_client(void *args) {
 					continue; // cant fall through to 0, so loop around back to this to jump to 4
 				}
 				case 0: {
-					n = recv(sockfd, &s_header, sizeof(T_DATUM_PROTOCOL_HEADER), MSG_DONTWAIT);
+					n = recv(sockfd, s_header_wire, T_DATUM_PROTOCOL_HEADER_WIRE_BYTES, MSG_DONTWAIT);
 					if (n <= 0) {
 						if ((n < 0) && ((errno == EAGAIN || errno == EWOULDBLOCK))) {
 							continue;
@@ -3222,12 +3239,12 @@ void *datum_protocol_client(void *args) {
 						DLOG_DEBUG("recv() issue. protocol_state=%d, n=%d, errno=%d (%s)", protocol_state, n, errno, strerror(errno));
 						break_again = true; break;
 					}
-					if (n != sizeof(T_DATUM_PROTOCOL_HEADER)) {
+					if (n != T_DATUM_PROTOCOL_HEADER_WIRE_BYTES) {
 						if (n > 4) {
 							DLOG_DEBUG("recv() issue. too many header bytes (B). protocol_state=%d, n=%d, errno=%d (%s)", protocol_state, n, errno, strerror(errno));
 							break_again = true; break;
 						}
-						protocol_state = sizeof(T_DATUM_PROTOCOL_HEADER)-n;
+						protocol_state = T_DATUM_PROTOCOL_HEADER_WIRE_BYTES-n;
 						continue;
 					}
 					
@@ -3237,9 +3254,7 @@ void *datum_protocol_client(void *args) {
 				}
 				
 				case 4: {
-					datum_xor_header_key(&s_header, receiving_header_key);
-					//DLOG_DEBUG("Server CMD: cmd=%u, len=%u, raw = %8.8x ... rkey = %8.8x", s_header.proto_cmd, s_header.cmd_len, upk_u32le(s_header, 0), receiving_header_key);
-					receiving_header_key = datum_header_xor_feedback(receiving_header_key);
+					datum_header_upk(&s_header, s_header_wire, 0, &receiving_header_key);
 					protocol_state = 5;
 					server_in_buf = 0;
 					if (!s_header.cmd_len) {

--- a/src/datum_protocol.h
+++ b/src/datum_protocol.h
@@ -72,14 +72,14 @@
 // It's likely possible to brute force the XOR key to break packets down into individual commands, but the contents and nature of the
 // cmd is still obfuscated and unrecoverable without the session keys.
 
-typedef struct __attribute__((packed)) T_DATUM_PROTOCOL_HEADER {
+typedef struct T_DATUM_PROTOCOL_HEADER {
 	uint32_t cmd_len:22; // max cmd size is 2^22 (~4MB), which is roughly the max block size for a raw submission or a raw template validation
-	uint8_t reserved:2; // save for later use
-	bool is_signed:1;
-	bool is_encrypted_pubkey:1;
-	bool is_encrypted_channel:1;
+	bool is_signed;
+	bool is_encrypted_pubkey;
+	bool is_encrypted_channel;
 	uint8_t proto_cmd:5; // 32 protocol level commands
 } T_DATUM_PROTOCOL_HEADER;
+#define T_DATUM_PROTOCOL_HEADER_WIRE_BYTES 4
 
 typedef struct {
 	bool is_remote;

--- a/src/datum_protocol_internal.h
+++ b/src/datum_protocol_internal.h
@@ -56,6 +56,8 @@ extern unsigned char datum_protocol_next_job_idx;
 extern T_DATUM_PROTOCOL_JOB datum_jobs[MAX_DATUM_PROTOCOL_JOBS];
 
 uint32_t datum_header_xor_feedback(uint32_t i);
+void datum_header_pk(uint8_t * const dst, const size_t offset, const T_DATUM_PROTOCOL_HEADER * const h, uint32_t * const xor_key);
+void datum_header_upk(T_DATUM_PROTOCOL_HEADER * const h, const uint8_t * const src, const size_t offset, uint32_t * const xor_key);
 int datum_protocol_flush_socket(int sockfd);
 void datum_protocol_bulk_reset(void);
 int datum_protocol_bulk_cmd_for_session(

--- a/src/datum_protocol_tests.c
+++ b/src/datum_protocol_tests.c
@@ -128,11 +128,9 @@ static int datum_protocol_test_decrypt_frame(const unsigned char *wire,
 	unsigned char nonce[crypto_box_NONCEBYTES],
 	T_DATUM_PROTOCOL_HEADER *header, unsigned char *clear,
 	size_t clear_size) {
-	if (*offset + sizeof(*header) > wire_size) return -1;
-	memcpy(header, wire + *offset, sizeof(*header));
-	*((uint32_t *)header) ^= *header_key;
-	*header_key = datum_header_xor_feedback(*header_key);
-	*offset += sizeof(*header);
+	if (*offset + T_DATUM_PROTOCOL_HEADER_WIRE_BYTES > wire_size) return -1;
+	datum_header_upk(header, wire, *offset, header_key);
+	*offset += T_DATUM_PROTOCOL_HEADER_WIRE_BYTES;
 	if (!header->is_encrypted_channel || header->cmd_len < crypto_box_MACBYTES ||
 	    *offset + header->cmd_len > wire_size ||
 	    header->cmd_len - crypto_box_MACBYTES > clear_size) return -1;
@@ -179,7 +177,7 @@ static void datum_protocol_bulk_tests(void) {
 	uint32_t receiver_header_key = sending_header_key;
 	unsigned char receiver_nonce[crypto_box_NONCEBYTES];
 	memcpy(receiver_nonce, session_nonce_sender, sizeof(receiver_nonce));
-	unsigned char wire[2 * (sizeof(T_DATUM_PROTOCOL_HEADER) +
+	unsigned char wire[2 * (T_DATUM_PROTOCOL_HEADER_WIRE_BYTES +
 		DATUM_BULK_FRAGMENT_HEADER_SIZE + DATUM_BULK_FRAGMENT_DATA_SIZE +
 		crypto_box_MACBYTES)];
 	unsigned char clear[DATUM_BULK_FRAGMENT_HEADER_SIZE +


### PR DESCRIPTION
## What
Your OCEAN #185 carried onto CONVOY master: the header is packed and unpacked explicitly instead of memcpy'd as a packed bitfield struct. Replaces #5. Your commit is kept as-is under your authorship; a second commit adapts the test frame decoder to go through the unpack helper.

## Why
You asked for #185 over the memcpy patch, and it fixes big-endian hosts and the MSVC bitfield warning as well as the aliasing. The April patch no longer applied: the send path is now the staged server_send_buffer and the receive reads the header in up to four pieces, so the pack and unpack calls sit at those three sites.

## How I tested
Built with -Wall -Werror, `--test` passes. The protocol tests decode every frame the gateway sends through datum_header_upk with the same feedback key sequence, so a mismatch between pack and unpack would fail them.
